### PR TITLE
WIP: UrlRequester additions

### DIFF
--- a/frescobaldi_app/widgets/urlrequester.py
+++ b/frescobaldi_app/widgets/urlrequester.py
@@ -38,6 +38,7 @@ class UrlRequester(QWidget):
 
     """
     changed = pyqtSignal()
+    editingFinished = pyqtSignal()
 
     def __init__(self, parent=None):
         super(UrlRequester, self).__init__(parent)
@@ -57,6 +58,7 @@ class UrlRequester(QWidget):
         layout.addWidget(self.button)
 
         self.lineEdit.textChanged.connect(self.changed)
+        self.lineEdit.editingFinished.connect(self.editingFinished)
         self.setFileMode(QFileDialog.Directory)
         app.translateUI(self)
 
@@ -113,5 +115,6 @@ class UrlRequester(QWidget):
         result = dlg.exec_()
         if result:
             self.lineEdit.setText(dlg.selectedFiles()[0])
+            self.editingFinished.emit()
 
 


### PR DESCRIPTION
Two (non-breaking) additions to the UrlRequester (which I need for something else):

* `editingFinished` signal  
Allows to perform validations that don't interfere with manual typing in the line edit (i.e. only validate after it loses focus)
* `mustExist` property  
If set to `True` the UrlRequester rejects entries that don't point to an existing file/directory (depending on `fileMode()`. In that case a message box is displayed and focus returned to the line edit. Empty paths are allowed, though