### PR TITLE
#1137: Fix (?) setting empty default list for inactive extensions

### DIFF
--- a/frescobaldi_app/extensions/__init__.py
+++ b/frescobaldi_app/extensions/__init__.py
@@ -817,7 +817,7 @@ class Extensions(QObject):
         s = QSettings()
         s.beginGroup('extension-settings')
         self._active = s.value('active', True, bool)
-        self._inactive_extensions = s.value('installed/inactive', [], list)
+        self._inactive_extensions = s.value('installed/inactive', [], str)
         self._root_directory = s.value('root-directory', '', str)
 
     def mainwindow(self):


### PR DESCRIPTION
https://stackoverflow.com/questions/37066961/pyqt4-saving-list-to-qsettings
indicates I had made a mistake by setting the default type to "list" instead
of the type "str" for the contained elements.
For some reason this did not break on Linux but only on Windows.

This *should* fix #1137 