### PR TITLE
Change icon theme along with GUI theme

### DIFF
--- a/frescobaldi_app/icons/__init__.py
+++ b/frescobaldi_app/icons/__init__.py
@@ -86,7 +86,13 @@ def initialize():
         QIcon.setThemeSearchPaths(QIcon.themeSearchPaths() + __path__)
         QIcon.setThemeName("TangoExt")
 
+def update_theme():
+    """Change the theme for icon lookup after change of style preference"""
+    QIcon.setThemeName(QSettings().value("guistyle", "", str))
+    # TODO: Redraw all widgets.
+    # Currently this only takes effect after restart.
+    # Widgets have to act upon the 
 
+app.settingsChanged.connect(update_theme)
+update_theme()
 app.oninit(initialize)
-
-


### PR DESCRIPTION
Closes #1158

Frescobaldi was looking for icons in the "current theme",
which is the desktop environment's theme. So if the theme
selected in the preferences is not "default" the icons will
not be looked up from the theme that is active in Frescobaldi,
which is improved in this commit.

@wbsoft: This is a WIP commit because the icons are *not*
updated immediately upon the settings change but only after
a restart. All widgets with icons have to be called to redraw
their icons, and I'm not sure whether there's a generic way
to do so, or if we have to provide that functionality in all
widgets/actions that use icons individually.