### PR TITLE
Fix python-ly error message bug

### DIFF
--- a/frescobaldi_app/main.py
+++ b/frescobaldi_app/main.py
@@ -142,7 +142,7 @@ def check_ly():
         "If you did install python-ly correctly, please remove the old\n"
         "ly package from the frescobaldi_app directory, or completely\n"
         "remove and then reinstall Frescobaldi."
-    ).format(version=".".join(format(d) for d in ly_required)))
+    ).format(version=".".join(format(d) for d in appinfo.required_python_ly_version)))
     sys.exit(1)
 
 


### PR DESCRIPTION
When running without python-ly installed, python throws an error: NameError: name 'ly_required' is not defined in main on line 145. Changing ly_required to appinfo.required_python_ly_version fixes this error.