### PR TITLE
Dev/urs/jobqueue (WIP)

### DIFF
--- a/frescobaldi_app/app.py
+++ b/frescobaldi_app/app.py
@@ -26,7 +26,10 @@ The global things in Frescobaldi.
 import os
 import sys
 
-from PyQt5.QtCore import QSettings, QThread
+from PyQt5.QtCore import (
+    QSettings,
+    QThread
+)
 from PyQt5.QtWidgets import QApplication
 
 import appinfo
@@ -58,6 +61,39 @@ sessionChanged = Signal()       # (name)
 saveSessionData = Signal()      # (name)
 jobStarted = Signal()           # (Document, Job)
 jobFinished = Signal()          # (Document, Job, bool success)
+
+
+# Number of phyiscally available CPU cores (if determined)
+_cores = QThread().idealThreadCount()
+if _cores == -1:
+    _cores = None
+
+def max_cores(fallback=True):
+    """
+    Return the number of physically available CPU cores.
+    If fallback=True (and the number can't be determined)
+    return a fallback of 16.
+    """
+    return _cores or (fallback and 16)
+
+def default_cores():
+    """
+    Return a default value for available cores
+    that is used in several places as long as the
+    user hasn't stored the max cores explictly.
+    """
+    return max(max_cores() - 1, 1)
+
+_available_cores = None
+
+def available_cores():
+    """
+    Return the number of requested runners for Frescobaldi.
+    """
+    if not _available_cores:
+        s = settings('multicore')
+        return s.value('num-cores', default_cores(), int)
+    return _available_cores
 
 
 def activeWindow():

--- a/frescobaldi_app/convert_ly.py
+++ b/frescobaldi_app/convert_ly.py
@@ -230,11 +230,11 @@ class Dialog(QDialog):
 
     def slotJobDone(self):
         j = self.job
-        if not j.success and j.failed_to_start():
+        if not j.success() and j.failed_to_start():
             self.messages.setPlainText(_(
                 "Could not start {convert_ly}:\n\n"
-                "{message}\n").format(convert_ly = j.command[0],
-                    message = j.error))
+                "{message}\n").format(convert_ly = j.command()[0],
+                    message = j.error()))
             return
         out = j.stdout()
         err = j.stderr()

--- a/frescobaldi_app/convert_ly.py
+++ b/frescobaldi_app/convert_ly.py
@@ -217,11 +217,11 @@ class Dialog(QDialog):
 
         self.job = j = job.Job(command, encoding='utf-8')
         if QSettings().value("lilypond_settings/no_translation", False, bool):
-            j.environment['LANG'] = 'C'
-            j.environment['LC_ALL'] = 'C'
+            j.set_environment('LANG', 'C')
+            j.set_environment('LC_ALL', 'C')
         else:
-            j.environment.pop('LANG', None)
-            j.environment.pop('LC_ALL', None)
+            j.environment().pop('LANG', None)
+            j.environment().pop('LC_ALL', None)
 
         j.done.connect(self.slotJobDone)
         app.job_queue().add_job(j, 'generic')

--- a/frescobaldi_app/debug.py
+++ b/frescobaldi_app/debug.py
@@ -38,7 +38,7 @@ def f(doc):
 @app.jobStarted.connect
 def f(doc, job):
     print('job started:', doc)
-    print(job.command)
+    print(' '.join(job.command()))
 
 @app.jobFinished.connect
 def f(doc, job, success):
@@ -68,5 +68,3 @@ app.appStarted()
 # be friendly and import Qt stuff
 from PyQt5.QtCore import *
 from PyQt5.QtGui import *
-
-

--- a/frescobaldi_app/documenticon.py
+++ b/frescobaldi_app/documenticon.py
@@ -61,7 +61,7 @@ class DocumentIconProvider(plugin.DocumentPlugin):
             icon = 'pushpin'
         elif doc.isModified():
             icon = 'document-save'
-        elif j and not j.is_running() and not j.is_aborted() and j.success:
+        elif j and not j.is_running() and not j.is_aborted() and j.success():
             icon = 'document-compile-success'
         elif j and not j.is_running() and not j.is_aborted():
             icon = 'document-compile-failed'

--- a/frescobaldi_app/engrave/__init__.py
+++ b/frescobaldi_app/engrave/__init__.py
@@ -187,17 +187,10 @@ class Engraver(plugin.MainWindowPlugin):
             else job.lilypond.PublishJob if mode == 'publish'
             else job.lilypond.LayoutControlJob
         )
-        # TODO: Try to move this argument creation into
-        # LayoutControlJob's constructor. However, somehow this has to
-        # obtain access to the mainwindow.
-        args = (
-            panelmanager.manager(
-                self.mainwindow()).layoutcontrol.widget().preview_options()
-            if mode == 'layout-control' else None)
         doc = document or self.document()
         if may_save:
             self.saveDocumentIfDesired()
-        self.runJob(job_class(doc, args), doc)
+        self.runJob(job_class(doc), doc)
 
     def engraveAbort(self):
         j = job.manager.job(self.document())

--- a/frescobaldi_app/engrave/custom.py
+++ b/frescobaldi_app/engrave/custom.py
@@ -210,11 +210,11 @@ class Dialog(QDialog):
 
         # Set environment variables for the job
         if self.englishCheck.isChecked():
-            j.environment['LANG'] = 'C'
-            j.environment['LC_ALL'] = 'C'
+            j.set_environment('LANG', 'C')
+            j.set_environment('LC_ALL', 'C')
         else:
-            j.environment.pop('LANG', None)
-            j.environment.pop('LC_ALL', None)
+            j.environment().pop('LANG', None)
+            j.environment().pop('LC_ALL', None)
         j.set_title("{0} {1} [{2}]".format(
             os.path.basename(j.lilypond_info.command),
                 j.lilypond_info.versionString(), document.documentName()))

--- a/frescobaldi_app/externalcommand.py
+++ b/frescobaldi_app/externalcommand.py
@@ -68,10 +68,10 @@ class ExternalCommandDialog(widgets.dialog.Dialog):
 
     def _closed(self):
         """(internal) Called when the user closes the dialog, calls cleanup()."""
-        if self.job.success is None:
+        if self.job.success() is None:
             self.job.abort()
             state = "aborted"
-        elif self.job.success:
+        elif self.job.success():
             state = "success"
         else:
             state = "failure"
@@ -89,5 +89,3 @@ class ExternalCommandDialog(widgets.dialog.Dialog):
 
         """
         pass
-
-

--- a/frescobaldi_app/file_export/__init__.py
+++ b/frescobaldi_app/file_export/__init__.py
@@ -110,9 +110,10 @@ class AudioExportDialog(externalcommand.ExternalCommandDialog):
     def midi2wav(self, midfile, wavfile):
         """Run timidity to convert the MIDI to WAV."""
         self.wavfile = wavfile # we could need to clean it up...
-        j = job.Job()
-        j.decoder_stdout = j.decoder_stderr = codecs.getdecoder('utf-8')
-        j.command = ["timidity", midfile, "-Ow", "-o", wavfile]
+        j = job.Job(
+            encoding='utf-8',
+            command=["timidity", midfile, "-Ow", "-o", wavfile]
+        )
         self.run_job(j)
 
     def cleanup(self, state):

--- a/frescobaldi_app/file_import/toly_dialog.py
+++ b/frescobaldi_app/file_import/toly_dialog.py
@@ -26,8 +26,16 @@ import os
 
 from PyQt5.QtCore import Qt
 
-from PyQt5.QtWidgets import (QCheckBox, QDialog, QDialogButtonBox,
-    QGridLayout, QLabel, QTabWidget, QTextEdit, QWidget)
+from PyQt5.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QGridLayout,
+    QLabel,
+    QTabWidget,
+    QTextEdit,
+    QWidget
+)
 
 import app
 import lilychooser
@@ -125,7 +133,9 @@ class ToLyDialog(QDialog):
         self.buttons.accepted.connect(self.about_to_accept)
         self.buttons.rejected.connect(self.reject)
 
-        self.lilyChooser.currentIndexChanged.connect(self.slot_lilypond_version_changed)
+        self.lilyChooser.currentIndexChanged.connect(
+            self.slot_lilypond_version_changed
+        )
         self.slot_lilypond_version_changed()
 
     def translateUI(self):
@@ -150,9 +160,9 @@ class ToLyDialog(QDialog):
             command=self._info.toolcommand(self._imp_prgm),
             input=self._input,
             output='--output={}'.format(output),
+            output_file=output,
             directory=os.path.dirname(self._input),
             encoding='utf-8')
-        j._output_file = output
 
     def get_post_settings(self):
         """Returns settings in the post import tab."""

--- a/frescobaldi_app/fonts/preview.py
+++ b/frescobaldi_app/fonts/preview.py
@@ -251,7 +251,6 @@ class FontsPreviewWidget(QWidget):
 
     def show_sample(self):
         """Display a sample document for the selected notation font."""
-        print("Enter show_sample")
         global_size = ''
         base_dir = None
         sample_content = ''
@@ -298,7 +297,6 @@ class FontsPreviewWidget(QWidget):
                     base_dir = os.path.dirname(current_doc.url().toLocalFile())
             else:
                 if target == 1:
-                    print("Custom file:", custom_file)
                     sample_file = custom_file
                 else:
                     # Engrave from a file

--- a/frescobaldi_app/fonts/textfonts.py
+++ b/frescobaldi_app/fonts/textfonts.py
@@ -535,7 +535,10 @@ class TextFonts(QObject):
         # TODO: Use the global JobQueue
         info = self.lilypond_info
         j = self.job = job.Job(
-            [info.abscommand() or info.command] + ['-dshow-available-fonts'])
+            self,
+            command=(
+                [info.abscommand() or info.command] + ['-dshow-available-fonts']
+            ))
         j.set_title(_("Available Fonts"))
         j.done.connect(self.process_results)
         if log_widget:

--- a/frescobaldi_app/job/__init__.py
+++ b/frescobaldi_app/job/__init__.py
@@ -110,7 +110,7 @@ class Job(object):
         self._runner = runner
         self._arguments = args if args else []
         self._directory = directory
-        self.environment = {}
+        self._environment = {}
         self._encoding = encoding
         self.success = None
         self.error = None
@@ -157,6 +157,23 @@ class Job(object):
 
     def set_directory(self, directory):
         self._directory = directory
+
+    def environment(self, key=None):
+        """
+        Return either one environment variable
+        or the whole dictionary (if key=None).
+        """
+        if key:
+            return self._environment[key]
+        else:
+            return self._environment
+
+    def set_environment(self, key, value):
+        """
+        Set a value in a job's environment.
+        If value is None the environment variable is removed.
+        """
+        self._environment[key] = value
 
     def filename(self):
         """File name of the job's input document.
@@ -227,7 +244,7 @@ class Job(object):
         self.start_message()
         if os.path.isdir(self._directory):
             self._process.setWorkingDirectory(self._directory)
-        if self.environment:
+        if self.environment():
             self._update_process_environment()
         self._process.start(self.command[0], self.command[1:])
 
@@ -306,7 +323,7 @@ class Job(object):
     def _update_process_environment(self):
         """(internal) initializes the environment for the process."""
         se = QProcessEnvironment.systemEnvironment()
-        for k, v in self.environment.items():
+        for k, v in self.environment().items():
             se.remove(k) if v is None else se.insert(k, v)
         self._process.setProcessEnvironment(se)
 

--- a/frescobaldi_app/job/__init__.py
+++ b/frescobaldi_app/job/__init__.py
@@ -53,31 +53,40 @@ STATUS = NEUTRAL | SUCCESS | FAILURE
 ALL = OUTPUT | STATUS
 
 
+def elapsed2str(seconds):
+    """Return a short display for the given time period (in seconds)."""
+    minutes, seconds = divmod(seconds, 60)
+    if minutes:
+        return "{0:.0f}'{1:.0f}\"".format(minutes, seconds)
+    return '{0:.1f}"'.format(seconds)
+
+
 class Job(object):
     """Manages a process.
 
-    Set the command attribute to a list of strings describing the program and
-    its arguments.
-    Set the directory attribute to a working directory.
-    The environment attribute is a dictionary; if you set an item it will be
-    added to the environment for the process (the rest will be inherited from
-    the system); if you set an item to None, it will be unset.
+    Configure the process through the key=value arguments to __init__
+    or later (but before starting the job) through property setters.
 
     Call start() to start the process.
-    The output() signal emits output (stderr or stdout) from the process.
-    The done() signal is always emitted when the process has ended.
-    The history() method returns all status messages and output so far.
+    - configure_command() will be called to compose the command to be used.
+      By default this will list the command name, arguments, input and output
+      (if present). Subclasses should override the _cmd_add_XXX methods
+      to configure how the slices are composed or the configure_command
+      method for more fundamental changes to the way a command is created.
+    - The output() signal emits output (stderr or stdout) from the process.
+    - The done() signal is always emitted when the process has ended.
+    - The history() method returns all status messages and output so far.
 
     When the process has finished, the error and success attributes are set.
-    The success attribute is set to True When the process exited normally and
+    The success() property is set to True when the process exited normally and
     successful. When the process did not exit normally and successfully, the
-    error attribute is set to the QProcess.ProcessError value that occurred
-    last. Before start(), error and success both are None.
+    error() property is set to the QProcess.ProcessError value that occurred
+    last. Before start(), error() and success() both are None.
 
     The status messages and output all are in one of five categories:
     STDERR, STDOUT (output from the process) or NEUTRAL, FAILURE or SUCCESS
     (status messages). When displaying these messages in a log, it is advised
-    to take special care for newlines, esp when a status message is displayed.
+    to take special care of newlines, esp. when a status message is displayed.
     Status messages normally have no newlines, so you must add them if needed,
     while output coming from the process may continue in the same line.
 
@@ -106,27 +115,43 @@ class Job(object):
         decode_errors='strict',
         encoding='latin1'
     ):
+        """
+        The following optional arguments can be pre-set (or specified later):
+        - command
+          a string list with the command name as its first element,
+          optionally followed by arguments
+        - args
+          arguments, if not already in the command string list
+        - directory
+          the job's working directory
+        - environment
+          a dictionary with enviroment variables to set/unset (value = None)
+        - input
+          an input statement as one out of
+          - a filename
+          - a filename wrapped in a list
+          - a list with an argument (e.g. '-i') and a filename
+        - input_file
+          an input file.
+          If this is not explicitly specified it will be taken from the
+          'input' option (or set to an empty string)
+        - output/output_file
+          corresponding to the input arguments
+        - priority
+          The priority the job will have if added to a priority job queue
+        - runner
+          A reference to a JobQueue's runner if that instantiates the job
+        - decode_errors
+          strategy for handling encoding issues in the communication
+          with external processes
+        - encoding
+          encoding of the process' input and output
+        """
         self._command = command if type(command) == list else [command]
-        self._input = (
-            input if type(input) == list
-            else [input] if input is not None
-            else []
-        )
-        self._input_file = (
-            input_file if input_file is not None
-            else self._input[-1] if self._input
-            else []
-        )
-        self._output = (
-            output if type(output) == list
-            else [output] if output is not None
-            else []
-        )
-        self._output_file = (
-            output_file if output_file is not None
-            else self._output[-1] if self._output
-            else []
-        )
+        self.set_input(input)
+        self.set_input_file(input_file)
+        self.set_output(output)
+        self.set_output_file(output_file)
         self._runner = runner
         self._arguments = args if args else []
         self._directory = directory
@@ -145,10 +170,181 @@ class Job(object):
         self._decoder_stdout = codecs.getdecoder(encoding)
         self._decode_errors = decode_errors  # codecs error handling
 
+    #
+    # "Private" methods
+    #
+
+    def _abort_message(self):
+        """Called by abort().
+
+        Outputs a message that the process has been aborted.
+
+        """
+        name = self.title() or os.path.basename(self._command[0])
+        self._message(_("Aborting {job}...").format(job=name), NEUTRAL)
+
+    def _bye(self, success):
+        """(internal) Ends and emits the done() signal."""
+        self._elapsed = time.time() - self._starttime
+        if not success:
+            self._error = self._process.error()
+        self._success = success
+        self._process.deleteLater()
+        self._process = None
+        self.done(success)
+
+    def _cmd_add_arguments(self):
+        """
+        Add the arguments to the command, if present.
+        Serialize tuples/lists if necessary.
+        """
+        self._command.extend(self.arguments())
+
+    def _cmd_add_input(self):
+        """
+        Add the input file or the input argument pair
+        to the command, if present.
+        """
+        self._command.extend(self._input or self._input_file)
+
+    def _cmd_add_output(self):
+        """
+        Add the output file or the output argument pair
+        to the command, if present.
+        """
+        self._command.extend(self._output or self._output_file)
+
+    def _configure_command(self):
+        """Process the command if necessary.
+
+        Initially the command is the list given upon instantiation.
+        The default implementation is to add (if present)
+        - arguments
+        - input file/argument pair
+        - output file/argument pair
+        to the initial command.
+
+        To specify the command to be used it is possible to
+        - instantiate job.Job and configure arguments, input and output
+        - subclass job.Job and override the three composing functions
+        - subclass job.Job and override configure_command.
+        """
+        # TODO: Maybe this order has to be made configurable
+        # by storing the functions in a list and calling them
+        # in a for loop - instead of requiring an override.
+        self._cmd_add_arguments()
+        self._cmd_add_input()
+        self._cmd_add_output()
+
+    def _error_message(self, error):
+        """Called when there is an error (by _slot_error()).
+
+        Outputs a message describing the given QProcess.Error.
+
+        """
+        if error == QProcess.FailedToStart:
+            self._message(_(
+                "Could not start {program}.\n"
+                "Please check path and permissions.").format(
+                    program=self._command[0]
+                ),
+                FAILURE
+            )
+        elif error == QProcess.ReadError:
+            self._message(_("Could not read from the process."), FAILURE)
+        elif self._process.state() == QProcess.NotRunning:
+            self._message(_("An unknown error occurred."), FAILURE)
+
+    def _finished(self, exitCode, exitStatus):
+        """(internal) Called when the process has finished."""
+        self._finish_message(exitCode, exitStatus)
+        success = exitCode == 0 and exitStatus == QProcess.NormalExit
+        self._bye(success)
+
+    def _finish_message(self, exitCode, exitStatus):
+        """Called when the process finishes (by _finished()).
+
+        Outputs a message on completion of the process.
+
+        """
+        if exitCode:
+            self._message(_(
+                "Exited with return code {code}."
+            ).format(code=exitCode), FAILURE)
+        elif exitStatus:
+            self._message(_(
+                "Exited with exit status {status}."
+            ).format(status=exitStatus), FAILURE)
+        else:
+            time = elapsed2str(self.elapsed_time())
+            self._message(_(
+                "Completed successfully in {time}."
+            ).format(time=time), SUCCESS)
+
+    def _message(self, text, type=NEUTRAL):
+        """
+        Output some text as the given type
+        (NEUTRAL, SUCCESS, FAILURE, STDOUT or STDERR).
+        """
+        self.output(text, type)
+        self._history.append((text, type))
+
+    def _readstderr(self):
+        """(internal) Called when STDERR can be read."""
+        output = self._process.readAllStandardError()
+        self._message(
+            self._decoder_stderr(output, self._decode_errors)[0], STDERR
+        )
+
+    def _readstdout(self):
+        """(internal) Called when STDOUT can be read."""
+        output = self._process.readAllStandardOutput()
+        self._message(
+            self._decoder_stdout(output, self._decode_errors)[0], STDOUT
+        )
+
+    def _set_process(self, process):
+        """Sets a QProcess instance and connects the signals."""
+        self._process = process
+        if process.parent() is None:
+            process.setParent(QCoreApplication.instance())
+        process.finished.connect(self._finished)
+        process.error.connect(self._slot_error)
+        process.readyReadStandardError.connect(self._readstderr)
+        process.readyReadStandardOutput.connect(self._readstdout)
+
+    def _slot_error(self, error):
+        """(internal) Called when an error occurs."""
+        self._error_message(error)
+        if self._process.state() == QProcess.NotRunning:
+            self._bye(False)
+
+    def _start_message(self):
+        """Called by start().
+
+        Outputs a message that the process has started.
+
+        """
+        name = self.title() or os.path.basename(self._command[0])
+        self._message(_("Starting {job}...").format(job=name), NEUTRAL)
+
+    def _update_process_environment(self):
+        """(internal) initializes the environment for the process."""
+        se = QProcessEnvironment.systemEnvironment()
+        for k, v in self.environment().items():
+            se.remove(k) if v is None else se.insert(k, v)
+        self._process.setProcessEnvironment(se)
+
+    #
+    # Properties
+    #
+
     def add_argument(self, arg):
-        """Append an additional command line argument if it is not
+        """
+        Append an additional command line argument if it is not
         present already.
-        arg may either be a single string or a key-value tuple."""
+        arg may either be a single string or a key-value tuple.
+        """
         k, v = arg if type(arg) == tuple else (arg, None)
         if k not in self._arguments:
             self._arguments.append(k)
@@ -158,36 +354,10 @@ class Job(object):
     def arguments(self):
         """
         Command arguments/options list.
-        Each entry may be a string or a key-value tuple/list.
-        In the default implementation they will be inserted after the
-        command name.
+        Override if arguments should be processed differently,
+        returning a string list.
         """
         return self._arguments
-
-    def _cmd_add_arguments(self):
-        """
-        Add the arguments to the command, if present.
-        Serialize tuples/lists if necessary.
-        """
-        for arg in self.arguments():
-            if type(arg) in [tuple, list]:
-                self._command.extend(arg)
-            else:
-                self._command.append(arg)
-
-    def _cmd_add_input(self):
-        """
-        Add the input file or the input argument pair
-        to the command, if present.
-        """
-        self._command.extend(self._input)
-
-    def _cmd_add_output(self):
-        """
-        Add the output file or the output argument pair
-        to the command, if present.
-        """
-        self._command.extend(self._output)
 
     def command(self):
         """
@@ -203,8 +373,19 @@ class Job(object):
     def set_directory(self, directory):
         self._directory = directory
 
+    def elapsed_time(self):
+        """Return how many seconds this process has been running."""
+        if self._elapsed:
+            return self._elapsed
+        elif self._starttime:
+            return time.time() - self._starttime
+        return 0.0
+
     def encoding(self):
         return self._encoding
+
+    def set_encoding(self, value):
+        self._encoding = value
 
     def environment(self, key=None):
         """
@@ -212,32 +393,109 @@ class Job(object):
         or the whole dictionary (if key=None).
         """
         if key:
-            return self._environment[key]
+            return self._environment.get(key, None)
         else:
             return self._environment
 
     def set_environment(self, key, value):
         """
         Set a value in a job's environment.
-        If value is None the environment variable is removed.
+        If value is None the environment variable will be removed
+        from the QProcess environment.
         """
         self._environment[key] = value
 
     def error(self):
+        """
+        Return the QProcess.ProcessError if the process produce it.
+        Before the process has finished this is always None.
+        """
         return self._error
 
-    # TODO: Maybe the following four properties are not needed at all
+    def failed_to_start(self):
+        """Return True if the process failed to start.
+
+        (Call this method after the process has finished.)
+
+        """
+        return self._error == QProcess.FailedToStart
+
+    def history(self, types=ALL):
+        """
+        Yield the output messages as two-tuples (text, type)
+        since the process started.
+
+        If types is given, it should be an OR-ed combination of the
+        status types STDERR, STDOUT, NEUTRAL, SUCCESS or FAILURE.
+
+        """
+        for msg, type in self._history:
+            if type & types:
+                yield msg, type
+
     def input(self):
+        """
+        Return the input clause, a list with either no element,
+        one filename or an argument/filename pair.
+        """
         return self._input
 
+    def set_input(self, input):
+        self._input = (
+            input if type(input) == list
+            else [input] if input is not None
+            else []
+        )
+
     def input_file(self):
-        return self._input_file
+        return self._input_file or ''
+
+    def set_input_file(self, input_file):
+        self._input_file = (
+            input_file if input_file is not None
+            else self._input[-1] if self._input
+            else []
+        )
+
+    def is_aborted(self):
+        """Returns True if the job was aborted by calling abort()."""
+        return self._aborted
+
+    def is_running(self):
+        """Returns True if this job is running."""
+        return bool(self._process)
 
     def output_arg(self):
+        """
+        Return the output clause, a list with either no element,
+        one filename or an argument/filename pair.
+        NOTE: the differing method name is because 'output' is
+        a job's signal.
+        """
         return self._output
 
+    def set_output(self, output):
+        self._output = (
+            output if type(output) == list
+            else [output] if output is not None
+            else []
+        )
+
     def output_file(self):
-        return self._output_file
+        return self._output_file or ''
+
+    def set_output_file(self, output_file):
+        self._output_file = (
+            output_file if output_file is not None
+            else self._output[-1] if self._output
+            else []
+        )
+
+    def priority(self):
+        return self._priority
+
+    def set_priority(self, value):
+        self._priority = value
 
     def runner(self):
         """Return the Runner object if the job is run within
@@ -248,6 +506,30 @@ class Job(object):
         """Store a reference to a Runner if the job is run within
         a JobQueue."""
         self._runner = runner
+
+    def start_time(self):
+        """Return the time this job was started.
+
+        Returns 0.0 when the job has not been started yet.
+
+        """
+        return self._starttime
+
+    def stderr(self):
+        """Return the standard error of the process as unicode text."""
+        return "".join([line[0] for line in self.history(STDERR)])
+
+    def stdout(self):
+        """Return the standard output of the process as unicode text."""
+        return "".join([line[0] for line in self.history(STDOUT)])
+
+    def success(self):
+        """
+        Return True if the job has completed, successfully,
+        False if it has finished with an error,
+        None if it hasn't been finished (or even started) yet.
+        """
+        return self._success
 
     def title(self):
         """Return the job title, as set with set_title().
@@ -267,16 +549,23 @@ class Job(object):
         if title != old:
             self.title_changed(title)
 
-    def priority(self):
-        return self._priority
+    #
+    # "Public" methods
+    #
 
-    def set_priority(self, value):
-        self._priority = value
+    def abort(self):
+        """Abort the process."""
+        if self._process:
+            self._aborted = True
+            self._abort_message()
+            if os.name == "nt":
+                self._process.kill()
+            else:
+                self._process.terminate()
 
     def start(self):
         """Starts the process."""
-        self.configure_command()
-        self._command
+        self._configure_command()
         self._success = None
         self._error = None
         self._aborted = False
@@ -284,225 +573,11 @@ class Job(object):
         self._elapsed = 0.0
         self._starttime = time.time()
         if self._process is None:
-            self.set_process(QProcess())
+            self._set_process(QProcess())
         self._process.started.connect(self.started)
-        self.start_message()
+        self._start_message()
         if os.path.isdir(self.directory() or ''):
             self._process.setWorkingDirectory(self.directory())
         if self.environment():
             self._update_process_environment()
         self._process.start(self._command[0], self._command[1:])
-
-    def configure_command(self):
-        """Process the command if necessary.
-
-        Initially the command is the list given upon instantiation.
-        The default implementation is to add (if present)
-        - arguments
-        - input file
-        - output file
-        to the initial command.
-
-        To specify the command to be used it is possible to
-        - instantiate job.Job and configure arguments, input and output
-        - subclass job.Job and override the three composing functions
-        - subclass job.Job and override configure_command.
-        """
-        # TODO: Maybe this order has to be made configurable
-        # by storing the functions in a list and calling them
-        # in a for loop - instead of requiring an override.
-        self._cmd_add_arguments()
-        self._cmd_add_input()
-        self._cmd_add_output()
-
-    def start_time(self):
-        """Return the time this job was started.
-
-        Returns 0.0 when the job has not been started yet.
-
-        """
-        return self._starttime
-
-    def elapsed_time(self):
-        """Return how many seconds this process has been running."""
-        if self._elapsed:
-            return self._elapsed
-        elif self._starttime:
-            return time.time() - self._starttime
-        return 0.0
-
-    def abort(self):
-        """Abort the process."""
-        if self._process:
-            self._aborted = True
-            self.abort_message()
-            if os.name == "nt":
-                self._process.kill()
-            else:
-                self._process.terminate()
-
-    def is_aborted(self):
-        """Returns True if the job was aborted by calling abort()."""
-        return self._aborted
-
-    def is_running(self):
-        """Returns True if this job is running."""
-        return bool(self._process)
-
-    def failed_to_start(self):
-        """Return True if the process failed to start.
-
-        (Call this method after the process has finished.)
-
-        """
-        return self._error == QProcess.FailedToStart
-
-    def set_process(self, process):
-        """Sets a QProcess instance and connects the signals."""
-        self._process = process
-        if process.parent() is None:
-            process.setParent(QCoreApplication.instance())
-        process.finished.connect(self._finished)
-        process.error.connect(self._slot_error)
-        process.readyReadStandardError.connect(self._readstderr)
-        process.readyReadStandardOutput.connect(self._readstdout)
-
-    def _update_process_environment(self):
-        """(internal) initializes the environment for the process."""
-        se = QProcessEnvironment.systemEnvironment()
-        for k, v in self.environment().items():
-            se.remove(k) if v is None else se.insert(k, v)
-        self._process.setProcessEnvironment(se)
-
-    def message(self, text, type=NEUTRAL):
-        """
-        Output some text as the given type
-        (NEUTRAL, SUCCESS, FAILURE, STDOUT or STDERR).
-        """
-        self.output(text, type)
-        self._history.append((text, type))
-
-    def history(self, types=ALL):
-        """
-        Yield the output messages as two-tuples (text, type)
-        since the process started.
-
-        If types is given, it should be an OR-ed combination of the
-        status types STDERR, STDOUT, NEUTRAL, SUCCESS or FAILURE.
-
-        """
-        for msg, type in self._history:
-            if type & types:
-                yield msg, type
-
-    def stdout(self):
-        """Return the standard output of the process as unicode text."""
-        return "".join([line[0] for line in self.history(STDOUT)])
-
-    def stderr(self):
-        """Return the standard error of the process as unicode text."""
-        return "".join([line[0] for line in self.history(STDERR)])
-
-    def success(self):
-        return self._success
-
-    def _finished(self, exitCode, exitStatus):
-        """(internal) Called when the process has finished."""
-        self.finish_message(exitCode, exitStatus)
-        success = exitCode == 0 and exitStatus == QProcess.NormalExit
-        self._bye(success)
-
-    def _slot_error(self, error):
-        """(internal) Called when an error occurs."""
-        self.error_message(error)
-        if self._process.state() == QProcess.NotRunning:
-            self._bye(False)
-
-    def _bye(self, success):
-        """(internal) Ends and emits the done() signal."""
-        self._elapsed = time.time() - self._starttime
-        if not success:
-            self._error = self._process.error()
-        self._success = success
-        self._process.deleteLater()
-        self._process = None
-        self.done(success)
-
-    def _readstderr(self):
-        """(internal) Called when STDERR can be read."""
-        output = self._process.readAllStandardError()
-        self.message(
-            self._decoder_stderr(output, self._decode_errors)[0], STDERR
-        )
-
-    def _readstdout(self):
-        """(internal) Called when STDOUT can be read."""
-        output = self._process.readAllStandardOutput()
-        self.message(
-            self._decoder_stdout(output, self._decode_errors)[0], STDOUT
-        )
-
-    def start_message(self):
-        """Called by start().
-
-        Outputs a message that the process has started.
-
-        """
-        name = self.title() or os.path.basename(self._command[0])
-        self.message(_("Starting {job}...").format(job=name), NEUTRAL)
-
-    def abort_message(self):
-        """Called by abort().
-
-        Outputs a message that the process has been aborted.
-
-        """
-        name = self.title() or os.path.basename(self._command[0])
-        self.message(_("Aborting {job}...").format(job=name), NEUTRAL)
-
-    def error_message(self, error):
-        """Called when there is an error (by _slot_error()).
-
-        Outputs a message describing the given QProcess.Error.
-
-        """
-        if error == QProcess.FailedToStart:
-            self.message(_(
-                "Could not start {program}.\n"
-                "Please check path and permissions.").format(
-                    program=self._command[0]
-                ),
-                FAILURE
-            )
-        elif error == QProcess.ReadError:
-            self.message(_("Could not read from the process."), FAILURE)
-        elif self._process.state() == QProcess.NotRunning:
-            self.message(_("An unknown error occurred."), FAILURE)
-
-    def finish_message(self, exitCode, exitStatus):
-        """Called when the process finishes (by _finished()).
-
-        Outputs a message on completion of the process.
-
-        """
-        if exitCode:
-            self.message(_(
-                "Exited with return code {code}."
-            ).format(code=exitCode), FAILURE)
-        elif exitStatus:
-            self.message(_(
-                "Exited with exit status {status}."
-            ).format(status=exitStatus), FAILURE)
-        else:
-            time = self.elapsed2str(self.elapsed_time())
-            self.message(_(
-                "Completed successfully in {time}."
-            ).format(time=time), SUCCESS)
-
-    @staticmethod
-    def elapsed2str(seconds):
-        """Return a short display for the given time period (in seconds)."""
-        minutes, seconds = divmod(seconds, 60)
-        if minutes:
-            return "{0:.0f}'{1:.0f}\"".format(minutes, seconds)
-        return '{0:.1f}"'.format(seconds)

--- a/frescobaldi_app/job/__init__.py
+++ b/frescobaldi_app/job/__init__.py
@@ -27,7 +27,11 @@ import codecs
 import os
 import time
 
-from PyQt5.QtCore import QCoreApplication, QProcess, QProcessEnvironment
+from PyQt5.QtCore import (
+    QCoreApplication,
+    QProcess,
+    QProcessEnvironment
+)
 
 import signals
 
@@ -84,9 +88,10 @@ class Job(object):
     output = signals.Signal()
     done = signals.Signal()
     started = signals.Signal()
-    title_changed = signals.Signal() # title (string)
+    title_changed = signals.Signal()  # title (string)
 
-    def __init__(self,
+    def __init__(
+        self,
         command=[],
         args=None,
         directory="",
@@ -97,7 +102,8 @@ class Job(object):
         priority=1,
         runner=None,
         decode_errors='strict',
-        encoding='latin1'):
+        encoding='latin1'
+    ):
         self.command = command if type(command) == list else [command]
         self._input = input
         self._output = output
@@ -122,7 +128,7 @@ class Job(object):
     def add_argument(self, arg):
         """Append an additional command line argument if it is not
         present already."""
-        if not arg in self._arguments:
+        if arg not in self._arguments:
             self._arguments.append(arg)
 
     def arguments(self):
@@ -148,7 +154,7 @@ class Job(object):
 
     def directory(self):
         return self._directory
-        
+
     def set_directory(self, directory):
         self._directory = directory
 
@@ -305,15 +311,20 @@ class Job(object):
         self._process.setProcessEnvironment(se)
 
     def message(self, text, type=NEUTRAL):
-        """Output some text as the given type (NEUTRAL, SUCCESS, FAILURE, STDOUT or STDERR)."""
+        """
+        Output some text as the given type
+        (NEUTRAL, SUCCESS, FAILURE, STDOUT or STDERR).
+        """
         self.output(text, type)
         self._history.append((text, type))
 
     def history(self, types=ALL):
-        """Yield the output messages as two-tuples (text, type) since the process started.
+        """
+        Yield the output messages as two-tuples (text, type)
+        since the process started.
 
-        If types is given, it should be an OR-ed combination of the status types
-        STDERR, STDOUT, NEUTRAL, SUCCESS or FAILURE.
+        If types is given, it should be an OR-ed combination of the
+        status types STDERR, STDOUT, NEUTRAL, SUCCESS or FAILURE.
 
         """
         for msg, type in self._history:
@@ -322,7 +333,7 @@ class Job(object):
 
     def stdout(self):
         """Return the standard output of the process as unicode text."""
-        return "".join([line[0] for line  in self.history(STDOUT)])
+        return "".join([line[0] for line in self.history(STDOUT)])
 
     def stderr(self):
         """Return the standard error of the process as unicode text."""
@@ -353,12 +364,16 @@ class Job(object):
     def _readstderr(self):
         """(internal) Called when STDERR can be read."""
         output = self._process.readAllStandardError()
-        self.message(self.decoder_stderr(output, self.decode_errors)[0], STDERR)
+        self.message(
+            self.decoder_stderr(output, self.decode_errors)[0], STDERR
+        )
 
     def _readstdout(self):
         """(internal) Called when STDOUT can be read."""
         output = self._process.readAllStandardOutput()
-        self.message(self.decoder_stdout(output, self.decode_errors)[0], STDOUT)
+        self.message(
+            self.decoder_stdout(output, self.decode_errors)[0], STDOUT
+        )
 
     def start_message(self):
         """Called by start().
@@ -387,7 +402,11 @@ class Job(object):
         if error == QProcess.FailedToStart:
             self.message(_(
                 "Could not start {program}.\n"
-                "Please check path and permissions.").format(program = self.command[0]), FAILURE)
+                "Please check path and permissions.").format(
+                    program=self.command[0]
+                ),
+                FAILURE
+            )
         elif error == QProcess.ReadError:
             self.message(_("Could not read from the process."), FAILURE)
         elif self._process.state() == QProcess.NotRunning:
@@ -400,12 +419,18 @@ class Job(object):
 
         """
         if exitCode:
-            self.message(_("Exited with return code {code}.").format(code=exitCode), FAILURE)
+            self.message(_(
+                "Exited with return code {code}."
+            ).format(code=exitCode), FAILURE)
         elif exitStatus:
-            self.message(_("Exited with exit status {status}.").format(status=exitStatus), FAILURE)
+            self.message(_(
+                "Exited with exit status {status}."
+            ).format(status=exitStatus), FAILURE)
         else:
             time = self.elapsed2str(self.elapsed_time())
-            self.message(_("Completed successfully in {time}.").format(time=time), SUCCESS)
+            self.message(_(
+                "Completed successfully in {time}."
+            ).format(time=time), SUCCESS)
 
     @staticmethod
     def elapsed2str(seconds):

--- a/frescobaldi_app/job/dialog.py
+++ b/frescobaldi_app/job/dialog.py
@@ -63,7 +63,7 @@ class Dialog(widgets.dialog.Dialog):
         self.exec()
 
     def slot_job_done(self):
-        if self.job.success:
+        if self.job.success():
             if self.auto_accept:
                 self.accept()
             self.button('ok').setEnabled(True)

--- a/frescobaldi_app/job/lilypond.py
+++ b/frescobaldi_app/job/lilypond.py
@@ -111,20 +111,24 @@ class LilyPondJob(Job):
                 self.lilypond_info.versionString(), doc.documentName()
             ))
 
+
         # initialize the Job basics
         super(LilyPondJob, self).__init__(
-                encoding='utf-8',
-                command=[
-                    self.lilypond_info.abscommand()
-                    or self.lilypond_info.command
-                ],
-                args=kwargs.get('args', None),
-                input=input,
-                decode_errors='replace',
-                directory=directory,
-                environment=environment,
-                title=title,
-                priority=2)
+            parent=kwargs.get('parent', None),
+            encoding='utf-8',
+            command=[
+                self.lilypond_info.abscommand()
+                or self.lilypond_info.command
+            ],
+            args=kwargs.get('args', None),
+            input=input,
+            decode_errors='replace',
+            directory=directory,
+            environment=environment,
+            title=title,
+            queue=kwargs.get('queue', 'engrave'),
+            priority=2
+        )
 
         # Initialize further, LilyPond-specific options from the given arguments
         self._d_options = kwargs.get('d_options', {})
@@ -357,7 +361,7 @@ class CachedPreviewJob(VolatileTextJob):
         md.update(text.encode('utf-8'))
         self.base_name = md.hexdigest()
         self.target_dir = kwargs.get('target_dir', self._target_dir)
-        self._needs_compilation = not os.path.exists(
+        self.needs_compilation = not os.path.exists(
             os.path.join(self.target_dir, self.base_name + '.pdf')
         )
         if self.needs_compilation:

--- a/frescobaldi_app/job/lilypond.py
+++ b/frescobaldi_app/job/lilypond.py
@@ -86,7 +86,7 @@ class LilyPondJob(Job):
     Code using the LilyPondJob class or its descendants doesn't explicitly
     deal with the 'command' list. Instead properties are set and options
     added from which the command line is implicitly composed in
-    configure_command().
+    _configure_command().
 
     """
 
@@ -197,7 +197,7 @@ class LilyPondJob(Job):
         """
         self._command.extend(self.paths(self._includepath))
 
-    def configure_command(self):
+    def _configure_command(self):
         """Compose the command line for a LilyPond job using all options.
         Individual steps may be overridden in subclasses."""
         self._cmd_add_d_options()

--- a/frescobaldi_app/job/lilypond.py
+++ b/frescobaldi_app/job/lilypond.py
@@ -116,8 +116,8 @@ class LilyPondJob(Job):
             "default_output_target", "pdf", str)
         self.embed_source_code = s.value("embed_source_code", False, bool)
         if s.value("no_translation", False, bool):
-            self.environment['LANG'] = 'C'
-            self.environment['LC_ALL'] = 'C'
+            self.set_environment('LANG', 'C')
+            self.set_environment('LC_ALL', 'C')
         self.set_title("{0} {1} [{2}]".format(
             os.path.basename(self.lilypond_info.command),
             self.lilypond_info.versionString(), doc.documentName()))

--- a/frescobaldi_app/job/lilypond.py
+++ b/frescobaldi_app/job/lilypond.py
@@ -126,8 +126,7 @@ class LilyPondJob(Job):
             directory=directory,
             environment=environment,
             title=title,
-            queue=kwargs.get('queue', 'engrave'),
-            priority=2
+            queue=kwargs.get('queue', 'engrave')
         )
 
         # Initialize further, LilyPond-specific options from the given arguments

--- a/frescobaldi_app/job/lilypond.py
+++ b/frescobaldi_app/job/lilypond.py
@@ -97,6 +97,10 @@ class LilyPondJob(Job):
 
         super(LilyPondJob, self).__init__(
                 encoding='utf-8',
+                command=[
+                    self.lilypond_info.abscommand()
+                    or self.lilypond_info.command
+                ],
                 args=args,
                 input=input,
                 decode_errors='replace',
@@ -158,13 +162,12 @@ class LilyPondJob(Job):
     def configure_command(self):
         """Compose the command line for a LilyPond job using all options.
         Individual steps may be overridden in subclasses."""
-        self._command = cmd = (
-            [self.lilypond_info.abscommand() or self.lilypond_info.command])
+        cmd = self._command
         cmd.extend(serialize_d_options(self._d_options))
         cmd.extend(self.arguments())
         cmd.extend(self.paths(self.includepath))
         cmd.extend(self.backend_args())
-        self.set_input_file()
+        self._cmd_add_input_file()
 
     def d_option(self, key):
         return self._d_options.get(key, None)

--- a/frescobaldi_app/job/lilypond.py
+++ b/frescobaldi_app/job/lilypond.py
@@ -158,7 +158,7 @@ class LilyPondJob(Job):
     def configure_command(self):
         """Compose the command line for a LilyPond job using all options.
         Individual steps may be overridden in subclasses."""
-        self.command = cmd = (
+        self._command = cmd = (
             [self.lilypond_info.abscommand() or self.lilypond_info.command])
         cmd.extend(serialize_d_options(self._d_options))
         cmd.extend(self.arguments())

--- a/frescobaldi_app/job/queue.py
+++ b/frescobaldi_app/job/queue.py
@@ -21,22 +21,47 @@
 A (multithreaded) Job queue.
 
 This module manages the resources spent on external processes
-within Frescobaldi.
+within Frescobaldi, all jobs are handled through this manager.
+
+A global job queue is available as app.job_queue(), holding a
+requested number of total Runners. By default three JobQueue
+items are present: "engrave", "generic" and "crawl", but custom
+queues can be added, for example by extensions.
+Job.start() will not start the job immediately but instead add
+it to the queue, which will in turn check if it can be started
+or has to be enqueued.
+
+Queues can be CONTINUOUS or SINGLE, which basically determines
+the behaviour when the last job has finished.
+
+Queues can request a number of dedicated runners and may share
+all or a specific number of shared runners. This ensures that
+a queue can have exclusive access to a given number or runners
+while avoiding to be overly agressive.
+
+The global job queue emits signals related to the jobs (job_added,
+job_enqueued etc.) which will occur *after* the corresponding
+signals of the jobs themselves. Additionally the queues emit
+signals when their states change.
+
+TODO: Not implemented yet is an option that SINGLE queues can
+request additional dedicated runners. These will be assigned
+when starting and released when finished. That makes it possible
+to use all resources for batch compilations.
 """
 
 from enum import Enum
 import collections
 import time
 
-from PyQt5.QtCore import (
-    QObject
-)
+from PyQt5.QtCore import QObject
 
 import app
 from signals import Signal
 
 
 class RunnerBusyException(Exception):
+
     """Runner is busy
 
     Raised when a Runner is asked to start a job (without the force=True
@@ -47,48 +72,76 @@ class RunnerBusyException(Exception):
 
 
 class Runner(QObject):
-    """A Runner in the stack of a JobQueue.
+
+    """A Runner in the stack of the global job queue.
 
     Responsible for executing a single job.Job instance.
-    Receives a job through the start command from the queue, reports
-    back about completion of the job. Any further actions are
-    managed by the queue.
+    Receives a job through the start command from a job queuequeue,
+    reports back about completion of the job. Any further actions
+    are managed by the queue.
 
-    References are kept to the queue and the job as well as the index
-    in the queue.
+    Upon first use app.job_queue() instantiates the requested number
+    of Runner objects. The runners originally populate a pool of
+    *shared* runners but may be assigned as dedicated runners
+    to specific job queues.
+    The remaining shared runners are temporarily assigned to job queues
+    and reclaimed after the job's completion.
+
+    Runners in the shared pool have the GlobalJobQueue as parent()
+    and are re-parented when assigned to a JobQueue as dedicated runner.
+    This means: runner.parent() does not necessarily point to the
+    queue the job has been enqued in. This can be retrieved through
+    runner.job().queue()
+
     """
 
-    def __init__(self, queue, index):
-        super(Runner, self).__init__(queue)
+    def __init__(self, parent, index):
+        super(Runner, self).__init__(parent)
         self._index = index
         self._job = None
-        self._completed = 0
+        self._completed_jobs = 0
 
-    def abort(self):
+    def abort(self, silent=False):
         """Aborts a running job if any."""
         if self.is_running():
             self._job.abort()
+        # TODO: Is job_done() still called or do I have to handle the
+        # case manually?
+        # (https://github.com/frescobaldi/frescobaldi/issues/1184)
+        # Especially note that the runner has to be "released".
+        #
+        # if silent=True it must be ensured that there is *no*
+        # call to JobQueue.job_completed. If the runner has to
+        # abort a current job to force-start a new one we don't
+        # want the runner handling from there. Maybe the signal
+        # should be sent anyway?
 
-    def completed(self):
+    def completed_jobs(self):
         """Return the number of jobs completed during the Runner's lifetime."""
-        return self._completed
+        return self._completed_jobs
 
     def index(self):
-        """Return the index of the Runner in the JobQueue."""
+        """Return the index of the Runner in the global pool."""
         return self._index
 
     def is_running(self):
         return bool(self._job and self._job.is_running())
 
+    def is_shared(self):
+        """Returns True if the runner is part of the shared runner pool.
+        This holds True even while the runner is stored within a queue."""
+        return self.parent() == app.job_queue()
+
     def job(self):
+        """Return the Job instance.
+        Is None when idle."""
         return self._job
 
-    def job_done(self):
+    def job_done(self, job):
         """Count job, remove reference to Job object and notify queue."""
-        if self._job.success():
-            self._completed += 1
-        job, self._job = self._job, None
+        self._completed_jobs += 1
         job.set_runner(None)
+        self._job = None
         job.queue().job_completed(self, job)
 
     def start(self, j, force=False):
@@ -97,19 +150,18 @@ class Runner(QObject):
         or raise an exception."""
         if self.is_running():
             if force:
-                self.abort()
+                self.abort(silent=True)
             else:
                 raise RunnerBusyException(
-                    _(string.format(
+                    _(
                         "Runner {ind} in Job Queue {q} is already running.\n"
-                        "Job: {title}",
-                        ind=self.index(),
-                        title=self._job.title(),
-                        q=self.parent().title()
-                    )))
+                        "Job: {title}".format(
+                            ind=self.index(),
+                            title=self._job.title(),
+                            q=self._job.queue().title()
+                        )))
         self._job = j
         j.set_runner(self)
-        j.done.connect(self.job_done)
         j._start()
 
 
@@ -124,26 +176,33 @@ class QueueFullException(QueueException):
 
 
 class AbstractQueue(QObject):
+
     """Common interface for the different queue types used in the JobQueue.
+
     The various queue classes are very lightweight wrappers around the
     corresponding concepts and base objects, with the only reason to
-    provide a transparent interface for used in JobQueue."""
+    provide a transparent interface for used in JobQueue.
+
+    parent should be the JobQueue using the queue.
+
+    If a capacity is given this limits the number of items that can be
+    added to the queue before raising an exception.
+    TODO: It *may* be of interest to add an option not to raise the exception
+    but rather to push out an element at the other end.
+
+    """
 
     def __init__(
         self,
-        job_queue=None,
+        parent=None,
         capacity=None
     ):
-        super(AbstractQueue, self).__init__(job_queue)
+        super(AbstractQueue, self).__init__(parent)
         self._capacity = capacity
 
     def clear(self):
         """Remove all entries from the queue."""
         raise NotImplementedError
-
-    def empty(self):
-        """Return True if there are no queued items."""
-        return self.length() == 0
 
     def full(self):
         """Return True if the capacity - if set - is complete."""
@@ -152,10 +211,19 @@ class AbstractQueue(QObject):
             and self.length() >= self._capacity
         )
 
+    def empty(self):
+        """Return True if there are no queued items."""
+        return self.length() == 0
+
     def length(self):
-        """Return the length of the queue. Only has to be overridden
-        when the data structure doesn't support len()."""
+        """Return the length of the queue. Has to be overridden
+        if the data structure doesn't support len()."""
         return len(self._queue)
+
+    def peek(self):
+        """Return a reference to the next element
+        that would be removed by pop()."""
+        raise NotImplementedError
 
     def _push(self, j):
         raise NotImplementedError
@@ -170,9 +238,12 @@ class AbstractQueue(QObject):
             raise QueueFullException(_("Trying to add item to full queue"))
         self._push(j)
 
-    def pop(self):
+    def _pop(self):
         """Remove and return the next job."""
         raise NotImplementedError
+
+    def pop(self):
+        return None if self.empty() else self._pop()
 
 
 class AbstractStackQueue(AbstractQueue):
@@ -182,7 +253,7 @@ class AbstractStackQueue(AbstractQueue):
         self,
         job_queue=None,
         capacity=None
-        ):
+    ):
         super(AbstractStackQueue, self).__init__(job_queue, capacity)
         self._queue = collections.deque()
 
@@ -190,7 +261,14 @@ class AbstractStackQueue(AbstractQueue):
         """Remove all entries from the queue."""
         self._queue.clear()
 
-    def pop(self):
+    def peek(self):
+        """
+        Return a reference to the next element
+        to be popped, but without removing it.
+        """
+        return None if self.empty() else self._queue[-1]
+
+    def _pop(self):
         return self._queue.pop()
 
 
@@ -209,9 +287,9 @@ class Stack(AbstractStackQueue):
 
 
 class PriorityQueue(AbstractQueue):
-    """Priority queue, always popping the job with the highest priority.
+    """Priority queue, always popping the job with the lowest priority.
 
-    Uses Job's priority() property (which defaults to 1) and a transparent
+    Uses Job's priority() property (which defaults to o) and a transparent
     insert count to determine order of popping jobs. If jobs have the same
     priority they will be served first-in-first-out."""
 
@@ -236,8 +314,12 @@ class PriorityQueue(AbstractQueue):
         heappush(self._queue, (j.priority(), self._insert_count, j))
         self._insert_count += 1
 
-    def pop(self):
-        """Return the correct part of the tuplet
+    def peek(self):
+        """Return the third element (the job) in the "lowest"/next entry."""
+        return self._queue[0][2] if not self.empty() else None
+
+    def _pop(self):
+        """Return the correct part of the tuple
         (1st: priority, 2nd: insert order)."""
         from heapq import heappop
         return heappop(self._queue)[2]
@@ -259,7 +341,20 @@ class JobQueueNotFoundException(JobQueueException):
     from the global JobQueue."""
     pass
 
+
 class QueueStatus(Enum):
+    """ Possible Queue states.
+
+    INACTIVE: Before even started, only interesting in SINGLE queues
+    STARTED:  Contains running and queued jobs, not paused
+    PAUSED:   Further jobs will not be started, but there may
+              be currently running or queued jobs
+    EMPTY:    No queued jobs, but there may be some still running
+    IDLE:     No queued or running jobs, but ready to start new ones
+    FINISHED: After the last job in a SINGLE queue has completed
+    ABORTED:  Queue has been aborted, but there may still be jobs running
+
+    """
     INACTIVE = 0
     STARTED = 1
     PAUSED = 2
@@ -270,44 +365,50 @@ class QueueStatus(Enum):
 
 
 class QueueMode(Enum):
+
     """Running mode of the JobQueue.
+
     CONTINUOUS means that the queue can be idle, waiting for new jobs,
-    SINGLE means that it will be considered finished when running empty."""
+    SINGLE means that it will be considered finished when running empty.
+
+    """
     CONTINUOUS = 0
     SINGLE = 1
 
 
 class JobQueue(QObject):
+
     """A (multiThreaded) Job Queue.
 
-    Manages a given number of "runners" which can process one job
-    at a time each.
+    Manages external resources for a specific purpose, assigning
+    jobs to dedicated and/or shared Runner objects.
 
-    An arbitrary number of job.Job() instances (or any descendants)
-    can be added to the queue, which are distributed in parallel
-    to the runners.
+    Runners can be requested to be dedicated to a queue.
+    This makes sure that the resources are exclusively avaiable to
+    the queue (e.g. the "crawler" will always have one runner
+    available) - but this also implies that the runner is *not*
+    available to others.
+
+    All runners that are not dedicated to a queue are in a pool of
+    shared runners and will be assigned to the next queued job.
+    TODO:
+    Right now GlobalJobQueue.reclaim_shared_runner has a trivial
+    approach to deciding which queue will get a free runner. This
+    has to be reconsidered and also (stress-)tested.
+
+    When calling Job.start() the job will be added to its assigned
+    job queue ("generic" by default, and "engrave" by default for
+    LilyPond jobs). The queue will then decide whether the job can
+    be started immediately or has to be enqueued.
 
     A special case is a queue with only one runner. This can be used
     to ensure that asynchronous jobs can run in sequence, either to
     ensure that only one such job runs at a time (e.g. to force
-    long-running stuff to the background) or to ensure subsequent
+    long-running stuff to the background) or to ensure that subsequent
     jobs can use the results of earlier ones.
 
     The queue supports pause(), resume() and abort() operations.
-    It iterates through the states
-    QueueStatus.INACTIVE
-                STARTED
-                PAUSED (remaining jobs won't be started)
-                EMPTY (no *new* jobs are queued)
-                IDLE (no new jobs available, all jobs completed)
-                FINISHED
-                ABORTED
-
-    A Queue can work in two modes: QueueMode.CONTINUOUS (default) and
-    QueueMode.SINGLE. In single mode the queue is considered finished once
-    there are no jobs available while a continuous queue switches to
-    IDLE in that case. A CONTINUOUS queue is always considered to be
-    active (idle when empty) and doesn't have to be explicitly started.
+    start() has only to be called explicitly for SINGLE mode queues.
 
     If a 'capacity' is passed to the queue it has the notion of "full",
     otherwise an unlimited number of jobs can be enqueued.
@@ -317,20 +418,15 @@ class JobQueue(QObject):
     available through the keyword command as well.
     """
 
+    # Signals relating to the queue as a whole
     started = Signal()
     paused = Signal()
     resumed = Signal()
-    emptied = Signal()  # emitted when last job is popped
+    empty = Signal()  # emitted when last job is popped
     idle = Signal()     # emitted when waiting for new jobs
                         # after the last job has been completed
     finished = Signal()
     aborted = Signal()
-    # The following three signals emit the corresponding job as argument.
-    job_added = Signal()
-    job_done = Signal() # emitted when a job has been completed.
-                        # When this is emitted, the queue's state has been
-                        # updated (other than with the *job's* signal)
-    job_started = Signal()
 
     def __init__(
         self,
@@ -353,14 +449,30 @@ class JobQueue(QObject):
         self._completed = 0
         self._queue = queue_class(self, capacity=capacity)
         self._runners = runners
+        for r in runners:
+            r.setParent(self)
+        self._running = []
+        self._shared_running = []
+        self._max_shared = max_shared
+        self.signals = {
+            QueueStatus.STARTED: self.started,
+            QueueStatus.PAUSED: self.paused,
+            QueueStatus.EMPTY: self.empty,
+            QueueStatus.IDLE: self.idle,
+            QueueStatus.FINISHED: self.finished,
+            QueueStatus.ABORTED: self.aborted
+        }
 
         if queue_mode == QueueMode.CONTINUOUS:
             self.start()
 
     def abort(self, force=True):
         """Abort the execution of the queued jobs.
+
         If force=True running jobs are aborted, otherwise
-        only the queue is cleared, allowing running jobs to finish."""
+        only the queue is cleared, allowing running jobs to finish.
+
+        """
         if self.state() in [
             QueueStatus.FINISHED,
             QueueStatus.ABORTED
@@ -368,208 +480,269 @@ class JobQueue(QObject):
             raise JobQueueStateException(
                 _("Inactive Job Queue can't be aborted")
             )
-        self.set_state(QueueStatus.ABORTED)
-        self.set_queue_mode(QueueMode.SINGLE)
+        # do not use set_state because we don't want
+        # to send the signal already now
+        self._state = QueueStatus.ABORTED
         self._queue.clear()
         if force:
-            for runner in self._runners:
-                if runner:
-                    # ignore runners that have already been set to None
-                    runner.abort()
-        self.aborted.emit()
+            for runner in self._running + self._shared_running:
+                runner.abort()
+
+    def enqueue_job(self, job):
+        """Enqueue a job
+
+        Called by add_job when the job can't be started immediately.
+        Push it to the internal queue, let job acknowledge the new state
+        and announce it.
+        """
+        self._queue.push(job)
+        job.enqueue()
+        app.job_queue().job_enqueued(job)
 
     def add_job(self, job):
-        """Enqueue a new job to the queue.
+        """Add a new job to the queue (enqueue/start).
 
         Some checks are made to determine the validity of adding a new job.
         If the queue hasn't started yet or is in pause the job is simply
         pushed to the queue, otherwise it will be determined whether an
         idle runner is available to start with the job immediately.
         """
-        if self.full():
-            raise IndexError(_("Job Queue full"))
-        if self.state() in [QueueStatus.FINISHED, QueueStatus.ABORTED]:
-            raise JobQueueStateException(
-                _("Can't add job to finished/aborted queue.")
-            )
-        elif self.state() in [QueueStatus.INACTIVE, QueueStatus.PAUSED]:
-            self._queue.push(job)
-            job.set_queue(self)
-            self.job_added.emit(job)
-        else:
-            runner = self.idle_runner()
-            if runner:
-                self.job_added.emit(job)
-                runner.start(job)
-                self.job_started.emit(job)
-            else:
-                self._queue.push(job)
-                job.set_queue(self)
-                self.job_added.emit(job)
-            self.set_state(
-                QueueStatus.EMPTY if self._queue.empty()
-                else QueueStatus.STARTED)
 
-    def completed(self, runner=-1):
-        """Return the number of completed jobs,
-        either for a given runner or the sum of all runners."""
-        if runner >= 0:
-            return self._runners[runner].completed()
+        if self.full():
+            raise IndexError(_("Job Queue '{}' full").format(self.title()))
+        elif self.state() in [QueueStatus.FINISHED, QueueStatus.ABORTED]:
+            raise JobQueueStateException(_(
+                "Can't add job '{job}' to finished/aborted queue '{queue}'."
+            ).format(
+                job=job.title(),
+                queue=self.title()
+            ))
         else:
-            result = 0
-            for i in range(len(self._runners)):
-                result += self._runners[i].completed()
-            return result
+            # The job can be added to the queue
+            app.job_queue().job_added(job)
+            if self.is_running():
+                self.set_state(QueueStatus.STARTED)
+                runner = self.idle_runner()
+                if runner:
+                    self.start_job(runner, job)
+                    return
+            # Queue is not running or no idle runner is available
+            self.enqueue_job(job)
+
+    def add_shared_runner(self, runner):
+        """Temporarily claim a shared runner.
+
+        The list is empty when no shared runners are used.
+        """
+        self._shared_running.append(runner)
 
     def full(self):
         """Returns True if a maximum capacity is set and used."""
         return self._queue.full()
 
+    def is_empty(self):
+        """Returns True if there are no queued jobs."""
+        return self._queue.empty()
+
     def is_idle(self):
-        """Returns True if all Runners are idle."""
-        for runner in self._runners:
-            if runner.is_running():
-                return False
-        return True
+        """Returns True if no Runners are in the _running lists
+        """
+        return not self._running + self._shared_running
 
     def is_running(self):
-        """Return True if the queue is 'live'."""
+        """Return True if the queue is 'live'.
+
+        This doesn't mean that there are running jobs, though.
+        """
         return self.state() not in ([
             QueueStatus.INACTIVE,
+            QueueStatus.PAUSED,
             QueueStatus.FINISHED,
             QueueStatus.ABORTED
         ])
 
     def idle_runner(self):
-        """Returns the first idle Runner object,
-        or None if all are busy."""
-        for runner in self._runners:
-            if not runner.is_running():
-                return runner
-        return None
+        """
+        Tries to locate an idle Runner object,
+        first in the queue's dedicated runners,
+        then requesting one from the shared pool.
+        """
+        # Find an idle dedicated runner and return it
+        if self._runners:
+            runner = self._runners.pop()
+            self._running.append(runner)
+            return runner
+        # If none is found and our limit to shared runners
+        # hasn't been reached, request one from the shared pool.
+        # Returns None if no shared runner is available.
+        if (
+            self.max_shared() == False
+            or len(self._shared_running) < self.max_shared()
+        ):
+            shared_runner = app.job_queue().idle_runner()
+            if shared_runner:
+                self.add_shared_runner(shared_runner)
+                return shared_runner
 
     def job_completed(self, runner, job):
         """Called by a runner once its job has completed.
 
-        Manage behaviour at that point, depending on the
-        queue's state and mode.
+        NOTE: runner.job() is already None at that point,
+        that's why the job is passed separately.
         """
-        if self.state() == QueueStatus.STARTED:
-            runner.start(self.pop())
-        elif self.state() == QueueStatus.PAUSED:
-            # If a SINGLE queue completes the last job while in PAUSE mode
-            # it can be considered finished.
-            if (
-                self._queue.empty()
-                and self.is_idle()
-                and self.queue_mode() == QueueMode.SINGLE
-            ):
-                self.queue_finished()
-        elif self.is_idle():
-            # last runner has completed its job and queue is empty.
-            # Either finish queue or set to IDLE.
-            if self.queue_mode() == QueueMode.SINGLE:
-                self.queue_finished()
+
+        new_state = None
+        cur_state = self.state()
+        cur_mode = self.queue_mode()
+        self.release_runner(runner)
+        # First update the state (if necessary)
+        if self.is_empty():
+            # there are no further jobs to add
+            if self.is_idle():
+                # and none running either
+                if cur_state == QueueStatus.STARTED:
+                    new_state = QueueStatus.IDLE
+                elif cur_state == QueueStatus.ABORTED:
+                    # We only signal this here because we didn't
+                    # do so in abort() (because abort may or may
+                    # not abort the individual jobs)
+                    self.job_aborted()
+                elif cur_mode == QueueMode.SINGLE:
+                    new_state = QueueStatus.FINISHED
             else:
-                self.set_idle()
-        self.job_done.emit(job)
+                # empty but other runners are still running
+                pass
+        else:
+            # There are further jobs in the queue, no need to do anything
+            pass
+
+        if new_state:
+            self.set_state(new_state)
+        app.job_queue().job_finished(job)
+
+        if runner.is_shared():
+            # Allow the global queue to start a job from an arbitrary queue
+            app.job_queue().reclaim_shared_runner(runner)
+        elif self.state() == QueueStatus.STARTED:
+            # Allow the next queued job to start
+            runner.start(self.pop())
+
+    def length(self):
+        """Return the number of unstarted jobs."""
+        return self._queue.length()
+
+    def max_shared(self):
+        """
+        Returns the maximum number of shared runners
+        this queue is allowed to request.
+        False if not limited.
+        """
+        return self._max_shared
 
     def name(self):
+        """The name (key) of the job queue. See also title()"""
         return self._name
 
     def pause(self):
         """Pauses the execution of the queue.
         Running jobs are allowed to finish, but no new jobs will be started.
-        (The actual behaviour is implemented in job_completed().)"""
-        if self.state() in [
-            QueueStatus.INACTIVE,
-            QueueStatus.FINISHED,
-            QueueStatus.ABORTED
-        ]:
+        (The actual behaviour is implemented in job_completed().)
+
+        TODO: This has to be properly tested.
+        """
+        if not self.is_running():
             raise JobQueueStateException(
                 _("Non-running Job Queue can't be paused.")
             )
         self.set_state(QueueStatus.PAUSED)
-        self.paused.emit()
+
+    def peek(self):
+        """Return a reference to the next job
+        that would be popped from this queue.
+        """
+        return self._queue.peek()
 
     def pop(self):
         """Return and remove the next Job.
         Raises Exception if empty."""
-        if self.state() == QueueStatus.EMPTY:
+        if self.is_empty():
             raise IndexError("Job Queue is empty.")
         if self.state() != QueueStatus.STARTED:
             raise JobQueueStateException(
                 _("Can't pop job from non-started Job Queue")
             )
         j = self._queue.pop()
-        if self._queue.empty():
+        if self.is_empty():
             self.set_state(QueueStatus.EMPTY)
-            self.emptied.emit()
         return j
-
-    def queue_finished(self):
-        """Called when the last job has been completed and the queue
-        is in SINGLE mode."""
-        if self.state() != QueueStatus.ABORTED:
-            self.set_state(QueueStatus.FINISHED)
-        self.finished.emit()
 
     def queue_mode(self):
         return self._queue_mode
 
+    def release_runner(self, runner):
+        """Release a runner from the shared or dedicated
+        runners reference list."""
+        try:
+            i = self._running.index(runner)
+            self._runners.append(self._running.pop(i))
+        except:
+            self._shared_running.remove(runner)
+
     def resume(self):
         """Resume the queue from PAUSED state by trying to start
-        all runners."""
+        all runners.
+
+        TODO: This has to be properly tested.
+        """
         if not self.state() == QueueStatus.PAUSED:
             raise JobQueueStateException(
                 _("Job Queue not paused, can't resume.")
             )
         self._start()
-        self.resumed.emit()
-
-    def set_idle(self):
-        """Set status to IDLE if all runners are in idle mode."""
-        for runner in self._runners:
-            if runner.is_running():
-                return
-        self.set_state(QueueStatus.IDLE)
-        self.idle.emit()
-
-    def set_queue_mode(self, mode):
-        self._queue_mode = mode
-
-    def size(self):
-        """Return the number of unstarted jobs."""
-        return self._queue.length()
+        self.resumed(self)
 
     def _start(self):
-        """Set the state to started and ask all runners to start."""
-        if self.state() in [QueueStatus.FINISHED, QueueStatus.ABORTED]:
-            raise JobQueueStateException(
+        """(Re)start the queue, also through resume().
+
+        Set the state to started and ask all runners to start.
+        """
+
+        def check_exceptions():
+            no_restart = JobQueueStateException(
                 _("Can't (re)start a finished/aborted Job Queue.")
             )
-        elif self.state() == QueueStatus.STARTED:
-            raise JobQueueStateException(_("Queue already started."))
-        if self.state() in [
-            QueueStatus.INACTIVE,
-            QueueStatus.PAUSED
-        ]:
-            self.set_state(QueueStatus.STARTED)
+            already_started = JobQueueStateException(
+                _("Queue already started.")
+            )
+            empty_single = IndexError(
+                _("Can't start SINGLE-mode empty queue")
+            )
+            exceptions = {
+                QueueStatus.FINISHED: no_restart,
+                QueueStatus.ABORTED: no_restart,
+                QueueStatus.STARTED: already_started,
+            }
+            exception = exceptions.get(self.state(), None)
+            if (
+                self.state() == QueueStatus.EMPTY
+                and self.queue_mode() == QueueMode.SINGLE
+            ):
+                exception = empty_single
+            if exception:
+                raise exception
 
-        if (
-            self.state() == QueueStatus.EMPTY
-            and self.queue_mode() == QueueMode.SINGLE
-        ):
-            raise IndexError(_("Can't start SINGLE-mode empty queue"))
-        if self._queue.empty():
-            self.set_idle()
+        check_exceptions()
+        self.set_state(QueueStatus.STARTED)
+        if self.is_empty():
+            self.set_state(QueueStatus.IDLE)
         else:
-            self.set_state(QueueStatus.STARTED)
-            for runner in self._runners:
-                if self._queue.empty():
+            runner = self.idle_runner()
+            while runner:
+                if self.is_empty():
+                    self.set_state(QueueStatus.EMPTY)
                     break
-                if not runner.is_running():
-                    runner.start(self.pop())
+                runner.start(self.pop())
+                runner = self.idle_runner()
 
     def start(self):
         """Start processing of the queue."""
@@ -578,15 +751,35 @@ class JobQueue(QObject):
                 _("Can't 'start' an active Job Queue."))
         self._starttime = time.time()
         self._start()
-        self.started.emit()
+        self.started()
+
+    def start_job(self, runner, job):
+        """Start a specific job.
+
+        Availability of job and runner have been determined before.
+        """
+        runner.start(job)
+        self.set_state(
+            QueueStatus.EMPTY if self.is_empty()
+            else QueueStatus.STARTED
+        )
+        app.job_queue().job_started(job)
 
     def set_state(self, state):
-        self._state = state
+        """Set the queue's state.
+
+        Set the state, and send the signal if this implies a change.
+        """
+        if self._state != state:
+            self._state = state
+            self.signals[state](self)
 
     def state(self):
+        """Return the queue's QueueStatus value."""
         return self._state
 
     def title(self):
+        """Return the queue's title."""
         return self._title
 
 
@@ -594,6 +787,28 @@ class GlobalJobQueue(QObject):
     """The application-wide Job Queue that dispatches jobs to runners
     and subordinate queues.
     """
+
+    # Signals related to individual queues, passing the queue as argument.
+    queue_started = Signal()
+    queue_paused = Signal()
+    queue_resumed = Signal()
+    queue_empty = Signal()
+    queue_idle = Signal()
+    queue_finished = Signal()
+    queue_aborted = Signal()
+
+    # Signals related to individual jobs, passing the job as argument.
+    # From there the queue may be retrieved, while the runner is
+    # already detached.
+    # Whenever a job is added the job_added signal is emitted,
+    # after that there may be job_enqueued. job_started is emitted
+    # when the job has actually started
+    job_added = Signal()
+    job_enqueued = Signal()
+    job_started = Signal()
+    job_finished = Signal() # emitted when a job has been completed.
+                        # When this is emitted, the queue's state has been
+                        # updated (other than with the *job's* signal)
 
     def __init__(self, parent=None):
         super(GlobalJobQueue, self). __init__(parent)
@@ -604,6 +819,8 @@ class GlobalJobQueue(QObject):
         self._shared_runners = [r for r in self._runners]
 
         self.load_settings()
+        self._queue_order = []
+        self._next_queue = -1
         self._create_queues()
         app.settingsChanged.connect(self.settings_changed)
         app.aboutToQuit.connect(self.about_to_quit)
@@ -613,15 +830,8 @@ class GlobalJobQueue(QObject):
         # - is any queue active?
         # - should jobs be aborted?
         # - or only the queues be emptied?
-        # - _crawler can always be aborted immediately
+        # - crawler can always be aborted immediately
         pass
-
-    def add_job(self, j, target='engrave'):
-        """
-        Add a job to the specified job queue.
-        """
-        target_queue = self.queue(target)
-        target_queue.add_job(j)
 
     def available_cores(self):
         """
@@ -633,9 +843,20 @@ class GlobalJobQueue(QObject):
     def available_shared(self):
         """
         Returns the number of shared runners.
-        Must not get below 1.
+        Must not get below 0.
         """
         return len(self._shared_runners)
+
+    def completed_jobs(self, runner=-1):
+        """Return the number of completed jobs,
+        either for a given runner or the sum of all runners."""
+        if runner >= 0:
+            return self._runners[runner].completed_jobs()
+        else:
+            result = 0
+            for runner in self._runners:
+                result += runner.completed_jobs()
+            return result
 
     def create_queue(self, name, title, dedicated=0, max_shared=False):
         """Create a new queue.
@@ -649,21 +870,29 @@ class GlobalJobQueue(QObject):
 
         """
 
-        if name in self._queues:
+        if name in self._queue_order:
             raise Exception("Queue of that name already exists.")
         elif self.available_shared() - dedicated < 1:
-            raise Exception("Can't assign so many dedicated runners")
-        self._queues[name] = JobQueue(
+            # TODO: Discuss if there really must be one shared runner left
+            # or if we could instead check whether all queues have at least
+            # one dedicated runner.
+            raise Exception("No shared runners left to be assigned")
+        self._queues[name] = queue = JobQueue(
             self,
+            name=name,
             title=title,
-            # This is preliminary!!! (manually share remaining runners)
-            # max_shared hasn't properly been implemented in JobQueue
-            runners=(
-                [self._runners.pop() for i in range(dedicated)]
-                + [r for r in self._runners]
-            ),
+            runners=([self._runners.pop() for i in range(dedicated)]),
             max_shared=max_shared
         )
+        self._queue_order.append(name)
+
+        queue.started.connect(self.queue_started)
+        queue.paused.connect(self.queue_paused)
+        queue.resumed.connect(self.queue_resumed)
+        queue.empty.connect(self.queue_empty)
+        queue.idle.connect(self.queue_idle)
+        queue.finished.connect(self.queue_finished)
+        queue.aborted.connect(self.queue_aborted)
 
     def _create_queues(self):
         """Create the initial main queues.
@@ -674,7 +903,7 @@ class GlobalJobQueue(QObject):
         - 'crawler' (for background jobs)
         Additional queues may be created by extensions.
 
-        - Has to use the settings
+        TODO: Has to use the settings
 
         """
 
@@ -703,6 +932,44 @@ class GlobalJobQueue(QObject):
             max_shared=False
         )
 
+    def get_next_job(self):
+        """Poll all queues for their next job.
+        If there are any, decide which one to start.
+        """
+
+        def next_queue_index():
+            """Return the index of the next queue
+
+            ... in a list that behaves like a ring buffer.
+            Used to index self._queue_order, which is populated
+            in the order of adding new queues.
+
+            """
+            self._next_queue = (self._next_queue + 1) % len(self._queue_order)
+            return self._next_queue
+
+        # retrieve the next job of each queue
+        # (or None if there is no job in the queue)
+        next_jobs = [self.queue(q).peek() for q in self._queue_order]
+        # Determine the next job to be executed.
+        # TODO: This is a naive approach:
+        #       cycle through the queues
+        #       and expect all queues to be served justly that way
+        # We need to discuss whether queues can be prioritized
+        # or whether/how the job's priorities can be respected
+        # while still giving all queues a fair share.
+        # E.g. respect priority but only everyt n-th turn ...
+        for i in range(len(next_jobs)):
+            next_queue = next_queue_index()
+            if next_jobs[next_queue]:
+                return self.queue(self._queue_order[next_queue]).pop()
+
+    def idle_runner(self):
+        """Return an idle runner from the shared pool,
+        or None if no runner is idle."""
+        if self._shared_runners:
+            return self._shared_runners.pop()
+
     def load_settings(self):
         # TODO: Load settings and create the JobQueues accordingly
         pass
@@ -721,6 +988,22 @@ class GlobalJobQueue(QObject):
                     "from the global JobQueue."
                 ).format(name=name)
             )
+
+    def reclaim_shared_runner(self, runner):
+        """Process a completed shared runner.
+
+        If a shared runner has completed its job
+        the global job queue tries to find a new job for it
+        (from an arbitrary job queue).
+
+        """
+        self._shared_runners.append(runner)
+        next_job = self.get_next_job()
+        if next_job:
+            self._shared_runners.pop()
+            queue = next_job.queue()
+            queue.add_shared_runner(runner)
+            queue.start_job(runner, next_job)
 
     def settings_changed(self):
         """Called when the application settings have been changed.

--- a/frescobaldi_app/layoutcontrol/__init__.py
+++ b/frescobaldi_app/layoutcontrol/__init__.py
@@ -32,38 +32,38 @@ import panel
 # dictionary mapping internal option names to command line switches
 _debugmodes = {
     'annotate-spacing':
-        ('-ddebug-annotate-spacing',
+        ('debug-annotate-spacing',
         lambda: _("Annotate Spacing"),
         lambda: _("Use LilyPond's \"annotate spacing\" option to\n"
           "display measurement information")),
     'control-points':
-        ('-ddebug-control-points',
+        ('debug-control-points',
         lambda: _("Display Control Points"),
         lambda: _("Display the control points that "
           "determine curve shapes")),
     'directions':
-        ('-ddebug-directions',
+        ('debug-directions',
         lambda: _("Color explicit directions"),
         lambda: _("Highlight elements that are explicitly switched up- or downwards")),
     'grob-anchors':
-        ('-ddebug-grob-anchors',
+        ('debug-grob-anchors',
         lambda: _("Display Grob Anchors"),
         lambda: _("Display a dot at the anchor point of each grob")),
     'grob-names':
-        ('-ddebug-grob-names',
+        ('debug-grob-names',
         lambda: _("Display Grob Names"),
         lambda: _("Display the name of each grob")),
     'paper-columns':
-        ('-ddebug-paper-columns',
+        ('debug-paper-columns',
         lambda: _("Display Paper Columns"),
         lambda: _("Display info on the paper columns")),
     'skylines':
-        ('-ddebug-display-skylines',
+        ('debug-display-skylines',
         lambda: _("Display Skylines"),
         lambda: _("Display the skylines that LilyPond "
           "uses to detect collisions.")),
     'voices':
-        ('-ddebug-voices',
+        ('debug-voices',
         lambda: _("Color \\voiceXXX"),
         lambda: _("Highlight notes that are explicitly "
         "set to \\voiceXXX")),
@@ -116,5 +116,3 @@ class LayoutControlOptions(panel.Panel):
         from . import widget
         w = widget.Widget(self)
         return w
-
-

--- a/frescobaldi_app/lilypondinfo.py
+++ b/frescobaldi_app/lilypondinfo.py
@@ -228,7 +228,7 @@ class LilyPondInfo(object):
 
         @j.done.connect
         def done():
-            success = j.success
+            success = j.success()
             if success:
                 output = ' '.join([line[0] for line in j.history()])
                 m = re.search(r"\d+\.\d+(.\d+)?", output)
@@ -274,7 +274,7 @@ class LilyPondInfo(object):
             "(display (ly:get-option 'datadir)) (newline) (exit)"])
         @j.done.connect
         def done():
-            success = j.success
+            success = j.success()
             if success:
                 output = [line[0] for line in j.history()]
                 d = output[1].strip('\n')

--- a/frescobaldi_app/logtool/errors.py
+++ b/frescobaldi_app/logtool/errors.py
@@ -90,7 +90,7 @@ class Errors(plugin.DocumentPlugin):
         """
         if type == job.STDERR:
             enc = sys.getfilesystemencoding()
-            job_enc = self._job._encoding
+            job_enc = self._job.encoding()
             for m in message_re.finditer(message.encode(job_enc)):
                 url = m.group(1).decode(enc)
                 filename = m.group(2).decode(enc)

--- a/frescobaldi_app/musicpreview.py
+++ b/frescobaldi_app/musicpreview.py
@@ -129,7 +129,7 @@ class MusicPreviewWidget(QWidget):
                 base_dir=base_dir,
                 title=title
             )
-            if not self._running.needs_compilation():
+            if not self._running.needs_compilation:
                 self._done(None)
                 return
         else:
@@ -149,7 +149,7 @@ class MusicPreviewWidget(QWidget):
             self._progress.start(self._lastbuildtime)
         if self._showWaiting:
             self._waiting.start()
-        app.job_queue().add_job(j, 'generic')
+        j.start()
 
     def _done(self, success):
         # TODO: Handle failed compilation (= no file to show)

--- a/frescobaldi_app/musicpreview.py
+++ b/frescobaldi_app/musicpreview.py
@@ -164,8 +164,6 @@ class MusicPreviewWidget(QWidget):
             return
         self._lastbuildtime = self._running.elapsed_time()
         self._stack.setCurrentWidget(self._view)
-        if self._current:
-            self._current.cleanup()
         self._current = self._running  # keep the tempdir
         self._running = None
 
@@ -189,10 +187,8 @@ class MusicPreviewWidget(QWidget):
     def cleanup(self):
         if self._running:
             self._running.abort()
-            self._running.cleanup()
             self._running = None
         if self._current:
-            self._current.cleanup()
             self._current = None
         if self._showLog:
             self._stack.setCurrentWidget(self._log)

--- a/frescobaldi_app/preferences/__init__.py
+++ b/frescobaldi_app/preferences/__init__.py
@@ -40,6 +40,7 @@ _prefsindex = 0 # global setting for selected prefs page but not saved on exit
 def pageorder():
     """Yields the page item classes in order."""
     yield General
+    yield Multicore
     yield LilyPond
     yield Midi
     yield Helpers
@@ -176,6 +177,17 @@ class General(PrefsItemBase):
     def widget(self, dlg):
         from . import general
         return general.GeneralPrefs(dlg)
+
+
+class Multicore(PrefsItemBase):
+    help = "prefs_multicore"
+    iconName = "preferences-other"
+    def translateUI(self):
+        self.setText(_("Multicore Support"))
+
+    def widget(self, dlg):
+        from . import multicore
+        return multicore.Multicore(dlg)
 
 
 class LilyPond(PrefsItemBase):

--- a/frescobaldi_app/preferences/multicore.py
+++ b/frescobaldi_app/preferences/multicore.py
@@ -1,0 +1,154 @@
+# This file is part of the Frescobaldi project, http://www.frescobaldi.org/
+#
+# Copyright (c) 2008 - 2014 by Wilbert Berendsen
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# See http://www.gnu.org/licenses/ for more information.
+
+"""
+Multicore support and job handling
+"""
+
+
+from PyQt5.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QSpinBox,
+    QVBoxLayout
+)
+
+import app
+import userguide
+import preferences
+
+from job import queue
+
+class Multicore(preferences.ScrolledGroupsPage):
+    def __init__(self, dialog):
+        super(Multicore, self).__init__(dialog)
+
+        layout = QVBoxLayout()
+        self.scrolledWidget.setLayout(layout)
+
+        layout.addWidget(Cores(self))
+        layout.addWidget(Queues(self))
+        layout.addStretch()
+
+
+class Cores(preferences.Group):
+    """Number of available CPU cores."""
+
+    def __init__(self, page):
+        super(Cores, self).__init__(page)
+
+        layout = QVBoxLayout()
+        self.setLayout(layout)
+
+        self.coresLabel = QLabel()
+        layout.addWidget(self.coresLabel)
+        self.numCores = QSpinBox(valueChanged=self.changed)
+        self.numCores.setRange(1, app.max_cores())
+
+        box = QHBoxLayout()
+        box.addWidget(self.numCores)
+        box.addStretch()
+        layout.addLayout(box)
+
+        app.translateUI(self)
+
+    def translateUI(self):
+        self.setTitle(_("Available CPU Cores/Threads"))
+        self.coresLabel.setText(_(
+                "The system reports {num} available cores or threads\n"
+                "Maximum number of cores to be used by Frescobaldi:"
+            ).format(num=app.max_cores(fallback=False) or '---')
+        )
+        self.coresLabel.setToolTip(_(
+            "The system has determined that this\n"
+            "is the number of threads or cores in\n"
+            "the CPU that can run in parallel."
+        ))
+
+    def loadSettings(self):
+        s = app.settings("multicore")
+        self.numCores.setValue(app.available_cores())
+
+    def saveSettings(self):
+        s = app.settings("multicore")
+        s.setValue('num-cores', self.numCores.value())
+
+
+class Queues(preferences.Group):
+    """Distribution of resources among job queues.
+    Thoughts:
+    - There is one global job queue which is assigned the requested number
+      of runners (TODO: Will runners be instantiated by sub-queues or
+      by the global queue and then assigned to a queue. The latter might
+      reduce complications when changing anything at runtime)
+    - The 'crawler' queue should always be separate with exactly one runner
+      -- except when only two cores are available in total.
+    - The 'generic' queue should generally be separate with exactly one runner.
+      This will be assigned jobs separate from the regular engraving, such
+      as import/exports or previews.
+      - When few cores are available this might better be merged with the
+        'engrave' queue.
+      - The merging could be unconditional or in a way that actual runners
+        are shared but that the 'generic' jobs are inserted with a higher
+        priority than engraving jobs. That way the 'generic' job will not
+        be started immediately but before the next engraving job gets started.
+      - The question is: this should *not* be allowed to swallow more slots
+        than assigned to the 'generic' queue. That is: If many engraving jobs
+        are queued and two generic jobs are added the second should only be
+        allowed to start after the first has completed.
+    - It is not clear how arbitrary additional queues (as created by extensions)
+      should be handled.
+      Maybe there should be a set of predefined "sharing strategies", from which
+      a queue has to choose one. Extensions should then choose an appropriate
+      strategy based on the available number of cores. It should make both the
+      strategy and the requested number of runners configurable, but it's
+      important to provide reasonable defaults.
+    - I *think* we should think of the 'engrave' queue as the center that is
+      always there, with all the other queues opting in to share with that pool
+      or requesting to take away from it.
+      At some point (when the engrave queue is requested to give away its last
+      runner) there will be an error message.
+
+    [EDIT:]
+    I think the best way to go is:
+    - have a shared pool of (all) available runners
+    - a new queue has a number of dedicated and a number of shared runners
+    - when creating a queue dedicated runners are popped from the shared pool
+    - in queue.available_slot (or so?) the queue will have to "know" whether
+      it may or may not use a shared runner, based on the max number
+    """
+
+    def __init__(self, page):
+        super(Queues, self).__init__(page)
+
+        layout = QVBoxLayout()
+        self.setLayout(layout)
+
+        app.translateUI(self)
+
+    def translateUI(self):
+        self.setTitle(_("Job Queues"))
+
+    def loadSettings(self):
+        s = app.settings("multicore")
+        # To be continued
+
+    def saveSettings(self):
+        s = app.settings("multicore")
+        # To be continued

--- a/frescobaldi_app/preferences/tools.py
+++ b/frescobaldi_app/preferences/tools.py
@@ -97,6 +97,7 @@ class LogTool(preferences.Group):
         self.showJobInfo.setText(_("Show detailed job info"))
         self.showJobInfo.setToolTip(_(
             "If checked the full command and additional\n"
+            "If checked the full command and additional\n"
             "information about the job and the job queue\n"
             "is given at the beginning of the log."
         ))

--- a/frescobaldi_app/preferences/tools.py
+++ b/frescobaldi_app/preferences/tools.py
@@ -79,6 +79,9 @@ class LogTool(preferences.Group):
         self.showlog = QCheckBox(toggled=self.changed)
         layout.addWidget(self.showlog)
 
+        self.showJobInfo = QCheckBox(toggled=self.changed)
+        layout.addWidget(self.showJobInfo)
+
         self.rawview = QCheckBox(toggled=self.changed)
         layout.addWidget(self.rawview)
 
@@ -91,6 +94,12 @@ class LogTool(preferences.Group):
         self.setTitle(_("LilyPond Log"))
         self.fontLabel.setText(_("Font:"))
         self.showlog.setText(_("Show log when a job is started"))
+        self.showJobInfo.setText(_("Show detailed job info"))
+        self.showJobInfo.setToolTip(_(
+            "If checked the full command and additional\n"
+            "information about the job and the job queue\n"
+            "is given at the beginning of the log."
+        ))
         self.rawview.setText(_("Display plain log output"))
         self.rawview.setToolTip(_(
             "If checked, Frescobaldi will not shorten filenames in the log output."""))
@@ -108,6 +117,9 @@ class LogTool(preferences.Group):
             self.fontChooser.setCurrentFont(font)
             self.fontSize.setValue(font.pointSizeF())
         self.showlog.setChecked(s.value("show_on_start", True, bool))
+        self.showJobInfo.setChecked(
+            s.value("show_command_info_on_start", False, bool)
+        )
         self.rawview.setChecked(s.value("rawview", True, bool))
         self.hideauto.setChecked(s.value("hide_auto_engrave", False, bool))
 
@@ -117,6 +129,7 @@ class LogTool(preferences.Group):
         s.setValue("fontfamily", self.fontChooser.currentFont().family())
         s.setValue("fontsize", self.fontSize.value())
         s.setValue("show_on_start", self.showlog.isChecked())
+        s.setValue("show_command_info_on_start", self.showJobInfo.isChecked())
         s.setValue("rawview", self.rawview.isChecked())
         s.setValue("hide_auto_engrave", self.hideauto.isChecked())
 
@@ -341,5 +354,3 @@ def is_regex(text):
     except re.error:
         return False
     return True
-
-


### PR DESCRIPTION
This is not intended for merging since the functionality is only halfway implemented so far. But I'd like to have it tested to see whether that half has been done properly, and maybe for some discussion about the way forward.

This builds on the multi-process job queue I had already implemented last year but starts making it properly available within Frescobaldi.
A global job queue manages a fixed number of runners that can execute external jobs in parallel. The point is not to *enable* parallel processing (which was possible since the beginning) but rather to *limit* it and control the use of resources. With the job queue it's possible to start literally thousands of jobs without either overwhelming the OS in managing them or having to execute them one by one. In a project I've successfully used that approach to have six cores permanently busy compiling hundreds of snippets.

There are three built-in queues, "engrave", "generic" and "crawl" that will be used for LilyPond jobs, general ones (like importing or convert-ly, or other jobs that extensions might launch), and I want to have a one-runner queue for "crawler" jobs to permanently do stuff like parsing autocomplete information etc.

Queues can request dedicated runners for exclusive access, and all remaining runners are shared between all queues. The three built-in queues are "continuous", i.e. running for the whole Frescobaldi session while custom queues can be set up as "single" to enqueue a fixed number of jobs and "finish". Such single queues will have the option (not implemented yet) to request more dedicated runners which are automatically released when the queue is finished. This is a way to temporarily give a batch process more resources at the cost of the overall operation.

Currently this is only partially implemented in so far as all three queues only use "shared" runners, and I haven't really thought about how the distribution of resources will be managed, and how the user is educated when making invalid requests (will there simply be a message saying "I don't have 27 cores at my disposal" or will be attempt a dynamic assignment etc.).

For testing please try out what happens when multiple jobs are started (including compiling multiple documents from tabs and starting processes like the score wizard preview, convert-ly, imports, or the document fonts dialog).
I suggest starting with Preferences=>Multicore=>Cores set to 1, which will force Frescobaldi to only use one external process at a time. So when you start more than one job consecutive jobs will only start when the previous job has finished. OTOH when you have more than one core the corresponding number of jobs will run in parallel.
*NOTE: While this may seem limiting it is an effort to prevent a loss of responsiveness due to overwhelming the OS with LilyPond processes.*

Note the small enhancments of the Log messages ;-)

See also https://github.com/frescobaldi/frescobaldi/issues/1176 for some things I have in mind for this functionality. Two really important use cases are:

* reserving one permanent runner for the background tasks that currently make Frescobaldi unresponsive with large and/or complex documents (as was confirmed to me a few days ago this can mean waiting minutes after each keystroke, which is totally unacceptable)
* providing support for batch processing, e.g. (one feature that may be added to Frescobaldi itself, everything else will be in extensions) "compile all `.ly` documents in the current directory.