### PR TITLE
Change default zoom levels

### DIFF
--- a/frescobaldi_app/musicview/__init__.py
+++ b/frescobaldi_app/musicview/__init__.py
@@ -58,7 +58,7 @@ from . import documents
 
 
 # default zoom percentages
-_zoomvalues = [50, 75, 100, 125, 150, 175, 200, 250, 300]
+_zoomvalues = [50, 75, 100, 125, 150, 200, 300, 800, 2400, 6400]
 
 # viewModes from qpageview:
 from qpageview import FixedScale, FitWidth, FitHeight, FitBoth


### PR DESCRIPTION
> it can zoom up to 6400% (vs previous 800%);

I hadn't noticed this before reading the comment.

Since the new qpageview can zoom up to 6400%
it is necessary to provide that value in the comboboxes too
(otherwise users wouldn't realize that feature).

The actual list in this commit is just a suggestion, though