### PR TITLE
Fix crashes when changing sessions

### DIFF
--- a/frescobaldi_app/viewers/popplerwidget.py
+++ b/frescobaldi_app/viewers/popplerwidget.py
@@ -26,7 +26,7 @@ Abstract base class for a Poppler based viewer widget.
 import os
 import weakref
 
-from PyQt5.QtCore import pyqtSignal, QPoint, QRect, Qt, QTimer, QUrl
+from PyQt5.QtCore import pyqtSignal, QPoint, QRect, Qt, QTimer, QUrl, QStringList
 from PyQt5.QtGui import QCursor, QTextCharFormat
 from PyQt5.QtWidgets import (
     QToolTip, QVBoxLayout, QHBoxLayout, QWidget, QToolBar)
@@ -298,7 +298,7 @@ class AbstractPopplerWidget(abstractviewwidget.AbstractViewWidget):
                 ds.removeAllViewdocs(update = False)
                 self.clear()
                 viewdocs = []
-                for v in session.value(files_key, ""):
+                for v in session.value(files_key, [], QStringList):
                     filename = v[0]
                     position = v[1]
                     doc = documents.Document(filename)

--- a/frescobaldi_app/viewers/popplerwidget.py
+++ b/frescobaldi_app/viewers/popplerwidget.py
@@ -26,7 +26,7 @@ Abstract base class for a Poppler based viewer widget.
 import os
 import weakref
 
-from PyQt5.QtCore import pyqtSignal, QPoint, QRect, Qt, QTimer, QUrl, QStringList
+from PyQt5.QtCore import pyqtSignal, QPoint, QRect, Qt, QTimer, QUrl
 from PyQt5.QtGui import QCursor, QTextCharFormat
 from PyQt5.QtWidgets import (
     QToolTip, QVBoxLayout, QHBoxLayout, QWidget, QToolBar)
@@ -290,6 +290,7 @@ class AbstractPopplerWidget(abstractviewwidget.AbstractViewWidget):
         session object and load them in the viewer."""
         if name:
             import sessions
+            import qsettings
             session = sessions.sessionGroup(name)
             if session.contains("urls"): # the session is not new
                 files_key = "{}-files".format(self.viewerName())
@@ -298,7 +299,7 @@ class AbstractPopplerWidget(abstractviewwidget.AbstractViewWidget):
                 ds.removeAllViewdocs(update = False)
                 self.clear()
                 viewdocs = []
-                for v in session.value(files_key, [], QStringList):
+                for v in qsettings.get_string_list(session, files_key):
                     filename = v[0]
                     position = v[1]
                     doc = documents.Document(filename)


### PR DESCRIPTION
I'm not sure whether this is the ultimate fix,
but I haven't seen any of these crashes anymore:

```
Traceback (most recent call last):
File
"/home/uliska/git/lilypond/frescobaldi/frescobaldi_app/sessions/menu.py",
line 115, in slotSessionsAction
manager.get(self.parentWidget()).startSession(action.objectName())
File
"/home/uliska/git/lilypond/frescobaldi/frescobaldi_app/sessions/manager.py",
line 90, in startSession
active = sessions.loadSession(name)
File
"/home/uliska/git/lilypond/frescobaldi/frescobaldi_app/sessions/__init__.py",
line 115, in loadSession
setCurrentSession(name)
File
"/home/uliska/git/lilypond/frescobaldi/frescobaldi_app/sessions/__init__.py",
line 157, in setCurrentSession
app.sessionChanged(name)
File "/home/uliska/git/lilypond/frescobaldi/frescobaldi_app/signals.py",
line 191, in emit
l.call(args, kwargs)
File "/home/uliska/git/lilypond/frescobaldi/frescobaldi_app/signals.py",
line 308, in call
return self.func(obj, *args[self.argslice], **kwargs)
File
"/home/uliska/git/lilypond/frescobaldi/frescobaldi_app/viewers/popplerwidget.py",
line 293, in slotSessionChanged
for v in session.value(files_key, ""):
TypeError: unable to convert a C++ 'QVariantList' instance to a Python
object
```

It was not enough to use `str` as the data type.