### PR TITLE
Display appinfo.version as ..-git

### DIFF
--- a/frescobaldi_app/about.py
+++ b/frescobaldi_app/about.py
@@ -106,7 +106,7 @@ class Version(QTextBrowser):
 def html():
     """Returns a HTML string for the about dialog."""
     appname = appinfo.appname
-    version = _("Version {version}").format(version = appinfo.version)
+    version = _("Version {version}").format(version = appinfo.running_version())
     description = _("A LilyPond Music Editor")
     copyright = _("Copyright (c) {year} by {author}").format(
         year = "2008-2019",

--- a/frescobaldi_app/app.py
+++ b/frescobaldi_app/app.py
@@ -119,7 +119,7 @@ def instantiate():
     args = list(map(os.fsencode, [os.path.abspath(sys.argv[0])] + sys.argv[1:]))
     qApp = QApplication(args)
     QApplication.setApplicationName(appinfo.name)
-    QApplication.setApplicationVersion(appinfo.version)
+    QApplication.setApplicationVersion(appinfo.running_version())
     QApplication.setOrganizationName(appinfo.name)
     QApplication.setOrganizationDomain(appinfo.domain)
     appInstantiated()

--- a/frescobaldi_app/appinfo.py
+++ b/frescobaldi_app/appinfo.py
@@ -41,3 +41,11 @@ required_python_ly_version = (0, 9, 4)
 
 # this one is used everywhere in the application
 appname = "Frescobaldi"
+
+def running_version():
+    import app
+    if app.is_git_controlled():
+        return "{}-git".format(version)
+    else:
+        return version
+    

--- a/frescobaldi_app/bugreport.py
+++ b/frescobaldi_app/bugreport.py
@@ -31,7 +31,7 @@ import debuginfo
 
 def email(subject, body, recipient=None):
     """Opens the e-mail composer with the given subject and body, with version information added to it."""
-    subject = "[{0} {1}] {2}".format(appinfo.appname, appinfo.version, subject)
+    subject = "[{0} {1}] {2}".format(appinfo.appname, appinfo.running_version(), subject)
     body = "{0}\n\n{1}\n\n".format(debuginfo.version_info_string('\n'), body)
     address = recipient or appinfo.maintainer_email
     url = QUrl("mailto:" + address)

--- a/frescobaldi_app/debuginfo.py
+++ b/frescobaldi_app/debuginfo.py
@@ -44,7 +44,7 @@ def _catch_unknown(f):
 @_catch_unknown
 def app_version():
     import appinfo
-    return appinfo.version
+    return appinfo.running_version()
 
 @_catch_unknown
 def sip_version():
@@ -104,7 +104,7 @@ if sys.platform.startswith('darwin'):
 
 def version_info_named():
     """Yield all the relevant names and their version string."""
-    yield appinfo.appname, appinfo.version
+    yield appinfo.appname, appinfo.running_version()
     yield "Extension API", appinfo.extension_api
     yield "Python", python_version()
     if app.is_git_controlled():

--- a/frescobaldi_app/file_export/__init__.py
+++ b/frescobaldi_app/file_export/__init__.py
@@ -66,7 +66,7 @@ class FileExport(plugin.MainWindowPlugin):
         xml = writer.musicxml()
         # put the Frescobaldi version in the xml file
         software = xml.root.find('.//encoding/software')
-        software.text = "{0} {1}".format(appinfo.appname, appinfo.version)
+        software.text = "{0} {1}".format(appinfo.appname, appinfo.running_version())
         try:
             xml.write(filename)
         except (IOError, OSError) as err:

--- a/frescobaldi_app/main.py
+++ b/frescobaldi_app/main.py
@@ -50,7 +50,7 @@ def parse_commandline():
     parser = argparse.ArgumentParser(conflict_handler="resolve",
         description = _("A LilyPond Music Editor"))
     parser.add_argument('-v', '--version', action="version",
-        version="{0} {1}".format(appinfo.appname, appinfo.version),
+        version="{0} {1}".format(appinfo.appname, appinfo.running_version()),
         help=_("show program's version number and exit"))
     parser.add_argument('-V', '--version-debug', action="store_true", default=False,
         help=_("show version numbers of {appname} and its supporting modules "

--- a/frescobaldi_app/preferences/import_export.py
+++ b/frescobaldi_app/preferences/import_export.py
@@ -249,5 +249,5 @@ def indentXml(elem, level=0, tab=2):
 
 
 _comment = """
-  Created by {appinfo.appname} {appinfo.version}.
+  Created by {appinfo.appname} {appinfo.running_version()}.
 """

--- a/frescobaldi_app/snippet/expand.py
+++ b/frescobaldi_app/snippet/expand.py
@@ -82,7 +82,7 @@ class Expander(object):
 
     @_("The version of Frescobaldi.")
     def FRESCOBALDI_VERSION(self):
-        return appinfo.version
+        return appinfo.running_version()
 
     @_("The URL of the current document.")
     def URL(self):

--- a/frescobaldi_app/snippet/import_export.py
+++ b/frescobaldi_app/snippet/import_export.py
@@ -217,7 +217,7 @@ def load(filename, widget):
 
 
 _comment = """
-  Created by {appinfo.appname} {appinfo.version}.
+  Created by {appinfo.appname} {appinfo.running_version()}.
 
   Every snippet is represented by:
     title:      title text

--- a/frescobaldi_app/splashscreen/__init__.py
+++ b/frescobaldi_app/splashscreen/__init__.py
@@ -30,7 +30,7 @@ import appinfo
 
 def show():
 
-    message = "{0}  {1} ".format(appinfo.appname, appinfo.version)
+    message = "{0}  {1} ".format(appinfo.appname, appinfo.running_version())
     pixmap = QPixmap(os.path.join(__path__[0], 'splash3.png'))
     if QApplication.desktop().screenGeometry().height() < 640:
         fontsize = 23

--- a/frescobaldi_app/userguide/resolve.py
+++ b/frescobaldi_app/userguide/resolve.py
@@ -34,7 +34,7 @@ def appname():
     return appinfo.appname
 
 def version():
-    return appinfo.version
+    return appinfo.running_version()
 
 def author():
     return appinfo.maintainer

--- a/macosx/build-dmg.sh
+++ b/macosx/build-dmg.sh
@@ -77,7 +77,7 @@ echo
 VERSION=$(${PYTHON} -c 'import os
 os.chdir("..")
 from frescobaldi_app import appinfo
-print(appinfo.version)')
+print(appinfo.running_version())')
 
 if git rev-parse --git-dir > /dev/null 2>&1
 then

--- a/macosx/mac-app.py
+++ b/macosx/mac-app.py
@@ -45,7 +45,7 @@ parser.add_argument('-f', '--force', action = 'store_true', \
   help = 'force execution even if SCRIPT does not exist')
 parser.add_argument('-v', '--version', \
   help = 'version string for the application bundle, \
-  visible e.g. in \'Get Info\' and in \'Open with...\'', default = appinfo.version)
+  visible e.g. in \'Get Info\' and in \'Open with...\'', default = appinfo.running_version())
 parser.add_argument('-s', '--script', \
   help = 'path of {0}\'s main script; you should use an absolute path, \
   so that the application bundle can be moved to another \

--- a/windows/freeze.py
+++ b/windows/freeze.py
@@ -174,7 +174,7 @@ Filename: "{{app}}\\frescobaldi.exe";\
  Flags: postinstall nowait skipifsilent;
 
 '''.format(
-    version=appinfo.version,
+    version=appinfo.running_version(),
     homepage=appinfo.url,
     author=appinfo.maintainer,
     comments=appinfo.description,

--- a/windows/frescobaldi-wininst.py
+++ b/windows/frescobaldi-wininst.py
@@ -111,7 +111,7 @@ def shortcut(directory):
 
 def welcome():
     """Prints a nice welcome message in the installer."""
-    print("\nWelcome to {0} {1}!".format(appinfo.appname, appinfo.version))
+    print("\nWelcome to {0} {1}!".format(appinfo.appname, appinfo.running_version()))
 
 
 ### Main:


### PR DESCRIPTION
When the application is run from Git show that in the
appinfo.version string (through the new
appinfo.running-version() function)

---

I'm not sure whether *all* of the changes are correct, namely in the files relating to translations and releases