### PR TITLE
Fix for using Arthur for Windows

### DIFF
--- a/frescobaldi_app/app.py
+++ b/frescobaldi_app/app.py
@@ -117,7 +117,9 @@ def instantiate():
     """Instantiate the global QApplication object."""
     global qApp
     args = list(map(os.fsencode, [os.path.abspath(sys.argv[0])] + sys.argv[1:]))
-    qApp = QApplication(args)
+    args.append("-platform") 
+    args.append("windows:fontengine=freetype") 
+    qApp = QApplication(args) 
     QApplication.setApplicationName(appinfo.name)
     QApplication.setApplicationVersion(appinfo.version)
     QApplication.setOrganizationName(appinfo.name)


### PR DESCRIPTION
With this fix, Arthur can be used by Windows. This basically appends the normally used command line parameter to the args vector which is read by QApplication.

The parameter normally only applies to windows, but to make sure I would like to have this tested in a Linux and Mac version before mergin it to master.