### PR TITLE
Set the desktopFileName property

### DIFF
--- a/frescobaldi_app/app.py
+++ b/frescobaldi_app/app.py
@@ -125,8 +125,9 @@ def instantiate():
         args.append("-platform") 
         args.append("windows:fontengine=freetype") 
     qApp = QApplication(args) 
-    QApplication.setApplicationName(appinfo.name)
+    QApplication.setApplicationName(appinfo.rdns_name)
     QApplication.setApplicationVersion(appinfo.version)
+    QApplication.setDesktopFileName(appinfo.rdns_name)
     QApplication.setOrganizationName(appinfo.name)
     QApplication.setOrganizationDomain(appinfo.domain)
     if sys.platform.startswith('darwin'):

--- a/frescobaldi_app/appinfo.py
+++ b/frescobaldi_app/appinfo.py
@@ -25,6 +25,7 @@ Information about the Frescobaldi application.
 
 # these variables are also used by the distutils setup
 name = "frescobaldi"
+rdns_name = "org.frescobaldi.Frescobaldi"
 version = "3.2"
 extension_api = "0.9.0"
 description = "LilyPond Music Editor"

--- a/frescobaldi_app/main.py
+++ b/frescobaldi_app/main.py
@@ -27,7 +27,7 @@ import re
 import sys
 
 from PyQt5.QtCore import QSettings, QTimer, QUrl
-from PyQt5.QtGui import QTextCursor
+from PyQt5.QtGui import QTextCursor, QGuiApplication
 from PyQt5.QtWidgets import QApplication
 
 import appinfo          # Information about our application
@@ -36,6 +36,9 @@ import install          # Update QSettings structure etc. if needed
 import guistyle         # Setup GUI style
 import i18n.setup       # Setup language
 import remote           # IPC with other Frescobaldi instances
+
+# It's needed by Qt Wayland backend. Requires Qt>=5.7.0
+QGuiApplication.setDesktopFileName("org.frescobaldi.Frescobaldi.desktop")
 
 
 def parse_commandline():

--- a/frescobaldi_app/main.py
+++ b/frescobaldi_app/main.py
@@ -27,7 +27,7 @@ import re
 import sys
 
 from PyQt5.QtCore import QSettings, QTimer, QUrl
-from PyQt5.QtGui import QTextCursor, QGuiApplication
+from PyQt5.QtGui import QTextCursor
 from PyQt5.QtWidgets import QApplication
 
 import appinfo          # Information about our application
@@ -36,9 +36,6 @@ import install          # Update QSettings structure etc. if needed
 import guistyle         # Setup GUI style
 import i18n.setup       # Setup language
 import remote           # IPC with other Frescobaldi instances
-
-# It's needed by Qt Wayland backend. Requires Qt>=5.7.0
-QGuiApplication.setDesktopFileName("org.frescobaldi.Frescobaldi.desktop")
 
 
 def parse_commandline():


### PR DESCRIPTION
Fix #1248: wrong app id and missing icon in GNOME on
Wayland.

I found the solution [here](https://github.com/IJHack/QtPass/pull/468).
I started working on this just for fun but I don't know what I'm really doing :-)

Now the icon is appearing in the left dash on GNOME.
In the topbar the application name is correct, but there's no icon.. only a kind of stylised F.
Unless I miss something, this patch finally allows to find Frescobaldi in GNOME Software,  even though the icon is not found. See below screenshots:

![fresco-top-icon](https://user-images.githubusercontent.com/1644647/73600699-57278a80-4554-11ea-8ead-908cc0f99a4f.png)

![fresco-gnome-dash](https://user-images.githubusercontent.com/1644647/73600701-5d1d6b80-4554-11ea-91cf-3da15d66e050.png)


