### PR TITLE
Fix Python selection on Mac

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,7 @@ Changes in 3.1.2 -- ?
     - end of line: cmd+right
   - fixed #1087, File names in document tabs are not shown correctly on Mac
   - fixed #1272, Global menu with no windows on Mac is not working
+  - fixed #1232, Error using convert-ly in Frescobaldi 3.1 Mac app
 
 
 Changes in 3.1.1 -- January 4th, 2020

--- a/frescobaldi_app/convert_ly.py
+++ b/frescobaldi_app/convert_ly.py
@@ -212,7 +212,7 @@ class Dialog(QDialog):
                 "Both 'from' and 'to' versions need to be set."))
             return
         info = self._info
-        command = info.toolcommand(info.ly_tool('convert-ly'))
+        command = info.toolcommand('convert-ly')
         command += ['-f', fromVersion, '-t', toVersion, '-']
 
         self.job = j = job.Job(command, encoding='utf-8')

--- a/frescobaldi_app/convert_ly.py
+++ b/frescobaldi_app/convert_ly.py
@@ -79,7 +79,7 @@ class Dialog(QDialog):
         self.reason = QLabel()
         self.toVersionLabel = QLabel()
         self.toVersion = QLineEdit()
-        self.lilyChooser = lilychooser.LilyChooser()
+        self.lilyChooser = lilychooser.LilyChooser(toolcommand='convert-ly')
         self.messages = QTextBrowser()
         self.diff = QTextBrowser(lineWrapMode=QTextBrowser.NoWrap)
         self.uni_diff = QTextBrowser(lineWrapMode=QTextBrowser.NoWrap)
@@ -157,6 +157,8 @@ class Dialog(QDialog):
         self.setWindowTitle(app.caption(title))
 
     def setLilyPondInfo(self, info):
+        if not info:
+            return
         self._info = info
         self.setCaption()
         self.toVersion.setText(info.versionString())

--- a/frescobaldi_app/file_import/toly_dialog.py
+++ b/frescobaldi_app/file_import/toly_dialog.py
@@ -147,7 +147,7 @@ class ToLyDialog(QDialog):
             os.path.join(util.tempdir(), os.path.basename(self._input))
             )[0] + '.ly'
         self._job = j = self._job_class(
-            command=self._info.toolcommand(self._info.ly_tool(self._imp_prgm)),
+            command=self._info.toolcommand(self._imp_prgm),
             input=self._input,
             output='--output={}'.format(output),
             directory=os.path.dirname(self._input),

--- a/frescobaldi_app/file_import/toly_dialog.py
+++ b/frescobaldi_app/file_import/toly_dialog.py
@@ -88,7 +88,7 @@ class ToLyDialog(QDialog):
                            self.runEngraverCheck]
 
         self.versionLabel = QLabel()
-        self.lilyChooser = lilychooser.LilyChooser()
+        self.lilyChooser = lilychooser.LilyChooser(toolcommand=self._imp_prgm)
 
         self.formatCheck.setObjectName("reformat")
         self.trimDurCheck.setObjectName("trim-durations")

--- a/frescobaldi_app/file_import/toly_dialog.py
+++ b/frescobaldi_app/file_import/toly_dialog.py
@@ -147,7 +147,7 @@ class ToLyDialog(QDialog):
             os.path.join(util.tempdir(), os.path.basename(self._input))
             )[0] + '.ly'
         self._job = j = self._job_class(
-            command=self._info.toolcommand(self._imp_prgm),
+            command=self._info.toolcommand(self._info.ly_tool(self._imp_prgm)),
             input=self._input,
             output='--output={}'.format(output),
             directory=os.path.dirname(self._input),

--- a/frescobaldi_app/lilychooser.py
+++ b/frescobaldi_app/lilychooser.py
@@ -30,9 +30,10 @@ import icons
 
 
 class LilyChooser(QComboBox):
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, toolcommand=None):
         super(LilyChooser, self).__init__(parent)
         self._infos = []
+        self._toolcommand = toolcommand
         app.translateUI(self)
         app.settingsChanged.connect(self.load)
         self.load()
@@ -55,6 +56,8 @@ class LilyChooser(QComboBox):
     def load(self):
         """Load the available LilyPond infos."""
         infos = lilypondinfo.infos() or [lilypondinfo.default()]
+        if self._toolcommand:
+            infos = [info for info in infos if info.toolcommand(self._toolcommand)]
         infos.sort(key = lambda i: i.version() or (999,))
         cur = self._infos[self.currentIndex()] if self._infos else lilypondinfo.preferred()
         self._infos = infos

--- a/frescobaldi_app/lilypondinfo.py
+++ b/frescobaldi_app/lilypondinfo.py
@@ -296,7 +296,7 @@ class LilyPondInfo(object):
             self.datadir = False
         app.job_queue().add_job(j, 'generic')
 
-    def toolcommand(self, command):
+    def toolcommand(self, command, use_ly_tool=True):
         """Return a list containing the commandline to run a tool, e.g. convert-ly.
 
         On Unix, the list has one element: the full path to the tool.
@@ -305,11 +305,14 @@ class LilyPondInfo(object):
         On Windows, the list has two elements: the LilyPond-provided Python
         interpreter and the tool path.
 
-        This does not automatically take into account the command the user
-        might have configured for the tool, use ly_tool() to get that command
-        name first, then this method to get the real command to run.
+        If use_ly_tool is True, this takes into account the command the user
+        might have configured for the tool, using ly_tool() to get that command
+        name first.
 
         """
+        if use_ly_tool:
+            command = self.ly_tool(command)
+
         bindir = self.bindir()
         if bindir:
             toolpath = os.path.join(self.bindir(), command)

--- a/frescobaldi_app/macosx/__init__.py
+++ b/frescobaldi_app/macosx/__init__.py
@@ -86,5 +86,5 @@ def system_python():
         python = '/System/Library/Frameworks/Python.framework/Versions/2.' + v
         python += '/bin/python2.' + v
         if os.path.exists(python):
-            return ['/usr/bin/arch', '-i386', python]
+            return ['/usr/bin/arch', '-i386', python, '-E']
 


### PR DESCRIPTION
I prefer this to be reviewed, since it is not trivial and does not touch only Mac-specific parts.

To test the new behaviour, you can artificially make `lilypondinfo.toolcommand` return `None` for some combinations of tool command and LilyPond version: the corresponding LilyPond entries should disappear from the list of the tool command.
You can also test with `lilypondinfo.toolcommand` always returning `None`, to see that it does not crash.