### PR TITLE
move arthurbackend_print preference to printing group

### DIFF
--- a/frescobaldi_app/install/__init__.py
+++ b/frescobaldi_app/install/__init__.py
@@ -28,7 +28,7 @@ import app
 
 # increase this number by one whenever something needs to be done, installed
 # or updated concerning the application settings.
-SETTINGS_VERSION = 1
+SETTINGS_VERSION = 2
 
 
 def update_settings():

--- a/frescobaldi_app/install/update.py
+++ b/frescobaldi_app/install/update.py
@@ -37,6 +37,9 @@ def update(version):
     if version < 1:
         moveSettingsToNewRoot()
 
+    if version < 2:
+        moveArthurbackendPrint()
+
     # ... add other setting updates here...
 
 
@@ -58,3 +61,11 @@ def moveSettingsToNewRoot():
                 s.setValue(k, o.value(k))
             o.clear()
 
+def moveArthurbackendPrint():
+    k = "arthurbackend_print"
+    oldk = "musicview/" + k
+    newk = "printing/" + k
+    s = QSettings()
+    if s.contains(oldk):
+        s.setValue(newk, s.value(oldk))
+        s.remove(oldk)

--- a/frescobaldi_app/pagedview.py
+++ b/frescobaldi_app/pagedview.py
@@ -264,7 +264,7 @@ def getPopplerBackends():
         renderBackend = popplerqt5.Poppler.Document.ArthurBackend
     else:
         renderBackend = popplerqt5.Poppler.Document.SplashBackend
-    if QSettings().value("musicview/arthurbackend_print", True, bool):
+    if QSettings().value("printing/arthurbackend_print", True, bool):
         printRenderBackend = popplerqt5.Poppler.Document.ArthurBackend
     else:
         printRenderBackend = popplerqt5.Poppler.Document.SplashBackend

--- a/frescobaldi_app/preferences/musicviewers.py
+++ b/frescobaldi_app/preferences/musicviewers.py
@@ -183,7 +183,7 @@ class Printing(preferences.Group):
 
     def loadSettings(self):
         s = QSettings()
-        useArthurPrint = s.value("musicview/arthurbackend_print", True, bool)
+        useArthurPrint = s.value("printing/arthurbackend_print", True, bool)
         self.printArthurBackend.setChecked(useArthurPrint)
         # see comment in pagedview and warning messages in musicview/__init__
         # and viewers/__init__ for the rationale for the default value
@@ -195,6 +195,6 @@ class Printing(preferences.Group):
 
     def saveSettings(self):
         s = QSettings()
-        s.setValue("musicview/arthurbackend_print", self.printArthurBackend.isChecked())
+        s.setValue("printing/arthurbackend_print", self.printArthurBackend.isChecked())
         s.setValue("printing/directcups", self.useCups.isChecked())
         s.setValue("printing/dpi", int(self.resolution.currentText()))


### PR DESCRIPTION
While testing this change, I had to run Frescobaldi twice for the install module to do its job.
Maybe before merging we should find out why that's happening.
How does it behave on Linux and Windows?