### PR TITLE
Allow nested docks

### DIFF
--- a/frescobaldi_app/mainwindow.py
+++ b/frescobaldi_app/mainwindow.py
@@ -93,6 +93,13 @@ class MainWindow(QMainWindow):
         QMainWindow.__init__(self)
         self.setAttribute(Qt.WA_DeleteOnClose)
 
+        # Add option to nest docks (useful on large screens)
+        self.setDockOptions(
+            QMainWindow.AllowNestedDocks |
+            QMainWindow.AnimatedDocks |
+             QMainWindow.AllowTabbedDocks
+        )
+
         # this could be made configurable
         self.setCorner(Qt.TopLeftCorner, Qt.LeftDockWidgetArea)
         self.setCorner(Qt.BottomLeftCorner, Qt.LeftDockWidgetArea)
@@ -149,6 +156,7 @@ class MainWindow(QMainWindow):
         app.mainwindowCreated(self)
         app.settingsChanged.connect(self.settingsChanged)
         self.settingsChanged()
+
 
     def documents(self):
         """Returns the list of documents in the order of the TabBar."""


### PR DESCRIPTION
The option of nesting dock areas is useful on large screens.

However, this would be good to be accompanied by a solution to #1321. When switching back to my significantly smaller laptop screen the layout is totally messed up.

This screenshot is not what I really want it to look like but demonstrates what is possible with this PR:

![grafik](https://user-images.githubusercontent.com/1812148/87057232-e4a78e80-c206-11ea-8a55-597e9cd6c19b.png)

The editor still is the main widget of the window. There's nothing in the top dock area but the left and right columns are heavily nested. Note in the music/SVG view that combining docks in tabs is still possible.