### PR TITLE
Let FilePathEdit choose not only directories

### DIFF
--- a/frescobaldi_app/widgets/listedit.py
+++ b/frescobaldi_app/widgets/listedit.py
@@ -85,7 +85,7 @@ class ListEdit(QWidget):
         item = self.listBox.currentItem()
         if item:
             self.removeItem(item)
-            
+
     def updateSelection(self):
         selected = bool(self.listBox.currentItem())
         self.editButton.setEnabled(selected)
@@ -190,3 +190,13 @@ class FilePathEdit(ListEdit):
             return True
         return False
 
+    def setFileMode(self, mode):
+        modes = {
+            'directory': QFileDialog.Directory,
+            QFileDialog.Directory: QFileDialog.Directory,
+            'file': QFileDialog.ExistingFile,
+            QFileDialog.ExistingFile: QFileDialog.ExistingFile,
+            'anyfile': QFileDialog.AnyFile,
+            QFileDialog.AnyFile: QFileDialog.AnyFile
+        }
+        self.fileDialog().setFileMode(modes[mode])


### PR DESCRIPTION
This is a convenience function to set the file mode of the included `QFileDialog`.
FilePathEdits may not only be useful for choosing directories.

I chose to add the option to pass in the value as a simple string so the caller doesn't have to include `QFileDialog`