### PR TITLE
Fixes #1379: Add explicit decoding of arguments.

### DIFF
--- a/frescobaldi_app/main.py
+++ b/frescobaldi_app/main.py
@@ -86,6 +86,9 @@ def parse_commandline():
 
     args = QApplication.arguments()
 
+    # Decode arguments to properly handle Unicode
+    args = [os.fsdecode(bytes(arg, 'mbcs')) for arg in args]
+
     # Strip interpreter name and its command line options on Windows
     if os.name == 'nt':
         while args:

--- a/frescobaldi_app/main.py
+++ b/frescobaldi_app/main.py
@@ -86,8 +86,9 @@ def parse_commandline():
 
     args = QApplication.arguments()
 
-    # Decode arguments to properly handle Unicode
-    args = [os.fsdecode(bytes(arg, 'mbcs')) for arg in args]
+    # Decode arguments to properly handle Unicode on Windows
+    if os.name == 'nt':
+        args = [os.fsdecode(bytes(arg, 'mbcs')) for arg in args]
 
     # Strip interpreter name and its command line options on Windows
     if os.name == 'nt':


### PR DESCRIPTION
While this is addressing a Windows-specific issue, the added logic should work on all platforms. As such, I have omitted an OS check in the code. Unfortunately, I am unable to test on Mac or Linux, so we would need to confirm this does not introduce any new problems before merging the PR.

The underlying issue is that `QApplication` unintentionally mangles the argument list that it gets passed due to differences in string handling. There was logic added to use `os.fsencode` but no corresponding call to `os.fsdecode` was present to reconstitute the arguments.