### PR TITLE
Fix engraving of unsaved files using relative pathnames without \include

### DIFF
--- a/frescobaldi_app/documentinfo.py
+++ b/frescobaldi_app/documentinfo.py
@@ -218,7 +218,7 @@ class DocumentInfo(plugin.DocumentPlugin):
             scratch = scratchdir.scratchdir(self.document())
             if create:
                 scratch.saveDocument()
-            if filename and self.lydocinfo().include_args():
+            if filename:
                 includepath.insert(0, os.path.dirname(filename))
             if create or (scratch.path() and os.path.exists(scratch.path())):
                 filename = scratch.path()


### PR DESCRIPTION
Unconditionally add directory of current LilyPond file to LilyPond
include directory list (-I ...) if engraving an unsaved file.
This enables use of relative paths in commands like \markup\epsfile ...
even if no actual \includes are being used in the .ly file.