### PR TITLE
Fix more errors under Python 3.10

### DIFF
--- a/frescobaldi_app/viewmanager.py
+++ b/frescobaldi_app/viewmanager.py
@@ -332,7 +332,7 @@ class ViewManager(QSplitter):
             splitter.setOrientation(orientation)
             size = splitter.sizes()[0]
             splitter.addWidget(newspace)
-            splitter.setSizes([size / 2, size / 2])
+            splitter.setSizes([size // 2, size // 2])
         elif splitter.orientation() == orientation:
             index = splitter.indexOf(viewspace)
             splitter.insertWidget(index + 1, newspace)
@@ -346,7 +346,7 @@ class ViewManager(QSplitter):
             splitter.setSizes(sizes)
             size = newsplitter.sizes()[0]
             newsplitter.addWidget(newspace)
-            newsplitter.setSizes([size / 2, size / 2])
+            newsplitter.setSizes([size // 2, size // 2])
         self._viewSpaces.insert(0, newspace)
         newspace.showDocument(viewspace.document())
         if active:

--- a/frescobaldi_app/widgets/linenumberarea.py
+++ b/frescobaldi_app/widgets/linenumberarea.py
@@ -80,7 +80,7 @@ class LineNumberArea(QWidget):
             if geom.top() >= ev.rect().bottom():
                 break
             if block.isVisible() and geom.bottom() > ev.rect().top() + 1:
-                rect.moveTop(geom.top())
+                rect.moveTop(int(geom.top()))
                 text = format(block.blockNumber() + 1, 'd')
                 painter.drawText(rect, Qt.AlignRight, text)
             block = block.next()


### PR DESCRIPTION
This commit addresses 2 more instances of an implicit cast to int which
causes an error under python 3.10.

The features that work properly after these changes are:
- Engraving a score
- Splitting the source view