### PR TITLE
Fix compiling source files with non-ASCII characters with LilyPond 2.23.6+

### DIFF
--- a/frescobaldi_app/convert_ly.py
+++ b/frescobaldi_app/convert_ly.py
@@ -219,11 +219,9 @@ class Dialog(QDialog):
 
         self.job = j = job.Job(command, encoding='utf-8')
         if QSettings().value("lilypond_settings/no_translation", False, bool):
-            j.environment['LANG'] = 'C'
-            j.environment['LC_ALL'] = 'C'
+            j.environment['LC_MESSAGES'] = 'C'
         else:
-            j.environment.pop('LANG', None)
-            j.environment.pop('LC_ALL', None)
+            j.environment.pop('LC_MESSAGES', None)
 
         j.done.connect(self.slotJobDone)
         app.job_queue().add_job(j, 'generic')

--- a/frescobaldi_app/engrave/custom.py
+++ b/frescobaldi_app/engrave/custom.py
@@ -213,11 +213,9 @@ class Dialog(QDialog):
 
         # Set environment variables for the job
         if self.englishCheck.isChecked():
-            j.environment['LANG'] = 'C'
-            j.environment['LC_ALL'] = 'C'
+            j.environment['LC_MESSAGES'] = 'C'
         else:
-            j.environment.pop('LANG', None)
-            j.environment.pop('LC_ALL', None)
+            j.environment.pop('LC_MESSAGES', None)
         j.set_title("{0} {1} [{2}]".format(
             os.path.basename(j.lilypond_info.command),
                 j.lilypond_info.versionString(), document.documentName()))

--- a/frescobaldi_app/job/lilypond.py
+++ b/frescobaldi_app/job/lilypond.py
@@ -117,8 +117,7 @@ class LilyPondJob(Job):
             "default_output_target", "pdf", str)
         self.embed_source_code = s.value("embed_source_code", False, bool)
         if s.value("no_translation", False, bool):
-            self.environment['LANG'] = 'C'
-            self.environment['LC_ALL'] = 'C'
+            self.environment['LC_MESSAGES'] = 'C'
         self.set_title("{0} {1} [{2}]".format(
             os.path.basename(self.lilypond_info.command),
             self.lilypond_info.versionString(), doc.documentName()))


### PR DESCRIPTION
In "Run LilyPond with English messages" mode, Frescobaldi used to set
the LC_ALL and LANG environment variable for the LilyPond process.
With versions of LilyPond that use Guile 2 (2.23.7 and later, 2.23.6
for some, also 2.22 from Homebrew), this breaks compiling files with
non-ASCII characters because unlike Guile 1, Guile 2 actually decodes
the filename string from the command line, and does so based on the
locale encoding.  Fix this by only setting LC_MESSAGES, which is
enough to stop localization of log messages without messing with the
encoding used to decode command line arguments.