### PR TITLE
fix #1471: typo in partCombine autocomplete

### DIFF
--- a/frescobaldi_app/autocomplete/completiondata.py
+++ b/frescobaldi_app/autocomplete/completiondata.py
@@ -82,7 +82,7 @@ start_music = (
     'alternative {',
     'relative',
     'transpose',
-    'partcombine',
+    'partCombine',
     'keepWithTag #\'',
     'removeWithTag #\'',
     'new',


### PR DESCRIPTION
Use camelCase instead of lowerCase.