### PR TITLE
Enable Python warnings

### DIFF
--- a/frescobaldi
+++ b/frescobaldi
@@ -28,6 +28,12 @@ frescobaldi_app contains the rest of the application.
 
 import sys
 
+# Enable all Python warnings, unless overridden (with
+# "python -W<something> frescobaldi").
+if not sys.warnoptions:
+    import warnings
+    warnings.simplefilter("default")
+
 from frescobaldi_app import toplevel
 toplevel.install()              # Add the path to frescobaldi_app to sys.path
 


### PR DESCRIPTION
Most users won't see them due to Frescobaldi's GUI nature, but Frescobaldi contributors now will. These warnings would have provided an advance notice for things like the float conversion issues that plagued Frescobaldi in Python 3.10.