### PR TITLE
Fix invalid escape sequence

### DIFF
--- a/frescobaldi_app/open_file_at_cursor.py
+++ b/frescobaldi_app/open_file_at_cursor.py
@@ -33,7 +33,7 @@ import documentinfo
 import browseriface
 
 # regular expression for finding \include expressions
-incl_regex = re.compile('(\\\\include\s*\")(.*)(\")')
+incl_regex = re.compile(r'(\\include\s*")([^"]*)(")')
 
 def includeTarget(cursor):
     """Given a cursor determine an absolute path to an include file present below the cursor.


### PR DESCRIPTION
Fixes the warning

home/jean/repos/frescobaldi/frescobaldi_app/open_file_at_cursor.py:36: DeprecationWarning: invalid escape sequence '\s'
  incl_regex = re.compile('(\\\\include\s*\")(.*)(\")')