### PR TITLE
fix #1081: Ignore inactive code in structure

### DIFF
--- a/frescobaldi_app/documentstructure.py
+++ b/frescobaldi_app/documentstructure.py
@@ -32,44 +32,59 @@ import plugin
 import lydocument
 import ly.document
 
+# default outline patterns that are ignored in comments
 default_outline_patterns = [
 r"(?P<title>\\(score|book|bookpart))\b",
 r"^\\(paper|layout|header)\b",
 r"\\(new|context)\s+[A-Z]\w+",
-r"(?P<title>BEGIN[^\n]*)[ \t]*$",
 r"^[a-zA-Z]+\s*=",
 r"^<<",
 r"^\{",
 r"^\\relative([ \t]+\w+[',]*)?",
+]
+
+# default outline patterns that are matched also in comments
+default_outline_patterns_comments = [
+r"(?P<title>BEGIN[^\n]*)[ \t]*$",
 r"\b(?P<alert>(FIXME|HACK|XXX+)\b\W*\w+)",
 ]
 
 
 # cache the outline regexp
 _outline_re = None
+_outline_re_comments = None
 
 
-def outline_re():
-    """Return the expression to look for document outline items."""
-    global _outline_re
-    if _outline_re is None:
-        _outline_re = create_outline_re()
-    return _outline_re
-
+def outline_re(comments):
+    """Return the expression to look for document outline items.
+    If comments is True it is used to search in the whole document,
+    if it is False comments are excluded."""
+    v = '_outline_re'+('_comments' if comments else '')
+    if globals()[v] is None:
+        globals()[v] = create_outline_re(comments)
+    return globals()[v]
 
 def _reset_outline_re():
     global _outline_re
+    global _outline_re_comments
     _outline_re = None
+    _outline_re_comments = None
 
 
 app.settingsChanged.connect(_reset_outline_re, -999)
 
 
-def create_outline_re():
-    """Create and return the expression to look for document outline items."""
+def create_outline_re(comments):
+    """Create and return the expression to look for document outline items.
+    If comments is True it is used to search in the whole document,
+    if it is False comments are excluded."""
     try:
-        rx = QSettings().value("documentstructure/outline_patterns",
-                               default_outline_patterns, str)
+        if comments:
+            rx = QSettings().value("documentstructure/outline_patterns_comments",
+                                   default_outline_patterns_comments, str)
+        else:
+            rx = QSettings().value("documentstructure/outline_patterns",
+                                default_outline_patterns, str)
     except TypeError:
         rx = []
     # suffix duplicate named groups with a number
@@ -106,8 +121,14 @@ class DocumentStructure(plugin.DocumentPlugin):
     def outline(self):
         """Return the document outline as a series of match objects."""
         if self._outline is None:
+            # match patterns excluding comments
             active_code = self.remove_comments()
-            self._outline = list(outline_re().finditer(active_code))
+            outline_list = list(outline_re(False).finditer(active_code))
+            # match patterns including comments
+            outline_list_comments = list(outline_re(True).finditer(self.document().toPlainText()))
+            # merge lists and sort by start position
+            self._outline = outline_list + outline_list_comments
+            self._outline.sort(key=lambda match: match.start())
             self.document().contentsChanged.connect(self.invalidate)
             app.settingsChanged.connect(self.invalidate, -999)
         return self._outline

--- a/frescobaldi_app/preferences/tools.py
+++ b/frescobaldi_app/preferences/tools.py
@@ -240,18 +240,33 @@ class Outline(preferences.Group):
         self.patternList.layout().addWidget(self.defaultButton, 3, 1)
         self.patternList.layout().addWidget(self.patternList.listBox, 0, 0, 5, 1)
         self.patternList.changed.connect(self.changed)
+        self.labelComments = QLabel()
+        self.patternListComments = OutlinePatterns()
+        self.patternListComments.listBox.setDragDropMode(QAbstractItemView.InternalMove)
+        self.defaultButtonComments = QPushButton(clicked=self.reloadDefaultsComments)
+        self.patternListComments.layout().addWidget(self.defaultButtonComments, 3, 1)
+        self.patternListComments.layout().addWidget(self.patternListComments.listBox, 0, 0, 5, 1)
+        self.patternListComments.changed.connect(self.changed)
         layout.addWidget(self.label)
         layout.addWidget(self.patternList)
+        layout.addWidget(self.labelComments)
+        layout.addWidget(self.patternListComments)
         app.translateUI(self)
 
     def translateUI(self):
         self.setTitle(_("Outline"))
         self.defaultButton.setText(_("Default"))
         self.defaultButton.setToolTip(_("Restores the built-in outline patterns."))
-        self.label.setText(_("Patterns to match in text that are shown in outline:"))
+        self.label.setText(_("Patterns to match in text (excluding comments) that are shown in outline:"))
+        self.defaultButtonComments.setText(_("Default"))
+        self.defaultButtonComments.setToolTip(_("Restores the built-in outline patterns."))
+        self.labelComments.setText(_("Patterns to match in text (including comments) that are shown in outline:"))
 
     def reloadDefaults(self):
         self.patternList.setValue(documentstructure.default_outline_patterns)
+
+    def reloadDefaultsComments(self):
+        self.patternListComments.setValue(documentstructure.default_outline_patterns_comments)
 
     def loadSettings(self):
         s = QSettings()
@@ -260,7 +275,12 @@ class Outline(preferences.Group):
             patterns = s.value("outline_patterns", documentstructure.default_outline_patterns, str)
         except TypeError:
             patterns = []
+        try:
+            patterns_comments = s.value("outline_patterns_comments", documentstructure.default_outline_patterns_comments, str)
+        except TypeError:
+            patterns_comments = []
         self.patternList.setValue(patterns)
+        self.patternListComments.setValue(patterns_comments)
 
     def saveSettings(self):
         s = QSettings()


### PR DESCRIPTION
This PR can be seen as a start of a more ambitious project to rewrite the structure code with the help of ly as a code parser instead of relying on regex. It's by necessity a little hacky to adapt to the overall implementation.