### PR TITLE
Deal with imp deprecation (redux)

### DIFF
--- a/frescobaldi_app/portmidi/__init__.py
+++ b/frescobaldi_app/portmidi/__init__.py
@@ -282,11 +282,21 @@ def _load_module(name):
     Raises ImportError when the module can't be found.
 
     """
-    import imp
-    path = None
+    from importlib.machinery import PathFinder
+    from importlib.util import module_from_spec
+
+    spec = None
     for n in name.split('.'):
-        file_handle, path, desc = imp.find_module(n, path and [path])
-    return imp.load_module(n, file_handle, path, desc)
+        if spec is not None:
+            path = spec.submodule_search_locations
+        else:
+            path = None
+        spec = PathFinder.find_spec(n, path)
+        if spec is None:
+            raise ImportError
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 # these functions try to import PortMIDI, returning the module
@@ -321,5 +331,3 @@ def _do_import_ctypes():
     """This tries to load PortMIDI via ctypes."""
     from . import ctypes_pypm
     return ctypes_pypm
-
-

--- a/windows/freeze.py
+++ b/windows/freeze.py
@@ -20,7 +20,7 @@ iscc = 'c:\\Program Files\\Inno Setup 5\\ISCC'
 target_dir = 'frozen'
 
 # import standard modules and cx_Freeze
-import imp
+import importlib.util
 import os
 import py_compile
 import shutil
@@ -35,7 +35,7 @@ sys.path.insert(0, '..')
 from frescobaldi_app import appinfo
 
 # find pypm by adding the dir of pygame to sys.path
-sys.path.append(imp.find_module('pygame')[1])
+sys.path.extend(importlib.util.find_spec('pygame').submodule_search_locations)
 
 includes = [
     'sip',
@@ -182,4 +182,3 @@ Filename: "{{app}}\\frescobaldi.exe";\
 )
 
 subprocess.Popen([iscc, '-'], stdin=subprocess.PIPE).communicate(inno_script)
-


### PR DESCRIPTION
[Redux of the broken and reverted commit https://github.com/Jean-Abou-Samra/frescobaldi/commit/0b05972c05386239843dbd62a1fae1a5cb763be4.]

imp is planned to be removed in Python 3.12.

The change in portmidi/__init__.py is inspired from
https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly

Fixes https://github.com/frescobaldi/frescobaldi/issues/1457