### PR TITLE
Do not suggest very old LilyPond version manual

### DIFF
--- a/frescobaldi_app/preferences/documentation.py
+++ b/frescobaldi_app/preferences/documentation.py
@@ -157,7 +157,6 @@ class LilyDocPathsList(widgets.listedit.ListEdit):
             icon = icons.get('lilypond-run'))
         urlreq = widgets.urlrequester.UrlRequester()
         urlreq.lineEdit.setCompleter(QCompleter([
-            "http://lilypond.org/doc/v2.12/",
             "http://lilypond.org/doc/stable/",
             "http://lilypond.org/doc/latest/",
             ], urlreq.lineEdit))


### PR DESCRIPTION
/doc/stable and /doc/latest are enough, as long as the redirects are promptly updated by the LilyPond team when a new stable is released.

<hr>

This is an easy patch. I'll merge it in a couple of days if there are no objections.
