### PR TITLE
correct jump to code from error log

### DIFF
--- a/frescobaldi_app/logtool/errors.py
+++ b/frescobaldi_app/logtool/errors.py
@@ -38,7 +38,7 @@ import util
 
 
 # finds file references (filename:line:col:) in messages
-message_re = re.compile(br"^((.*?):(\d+)(?::(\d+))?)(?=:)", re.M)
+message_re = re.compile(br"^((.*?):([1-9]\d*)(?::([1-9]\d*))?)(?=:)", re.M)
 
 
 def errors(document):
@@ -95,7 +95,7 @@ class Errors(plugin.DocumentPlugin):
                 url = m.group(1).decode(enc)
                 filename = m.group(2).decode(enc)
                 filename = util.normpath(filename)
-                line, column = int(m.group(3)), int(m.group(4) or 1) - 1
+                line, column = int(m.group(3)), int(m.group(4) or 1)
                 self._refs[url] = Reference(filename, line, column)
 
     def cursor(self, url, load=False):
@@ -114,7 +114,7 @@ class Reference(object):
     def __init__(self, filename, line, column):
         """Creates the reference to filename, line and column.
 
-        lines start numbering with 1, columns with 0 (LilyPond convention).
+        By LilyPond convention, lines and columns are numbered starting with 1.
 
         If a document with the given filename is already loaded (or the filename
         refers to the scratchdir for a document) a QTextCursor is created immediately.
@@ -140,15 +140,25 @@ class Reference(object):
         changes.
 
         """
-        b = document.findBlockByNumber(max(0, self._line - 1))
+        # message_re and Errors.slotJobOutput ensure that _line and _column are >= 1.
+        # _line or _column overrun defaults to end of document or line respectively.
+        self._cursor = c = QTextCursor(document)
+        document.closed.connect(self.unbind)
+        b = document.findBlockByNumber(self._line - 1)
         if b.isValid():
-            self._cursor = c = QTextCursor(document)
-            c.setPosition(b.position() + self._column)
-            document.closed.connect(self.unbind)
-            if self._line > 0:
-                bookmarks.bookmarks(document).setMark(self._line - 1, "error")
+            bookmarks.bookmarks(document).setMark(self._line - 1, "error")
+            line_text = b.text()
+            if len(line_text) >= self._column:
+                qchar_offset = len(line_text[:self._column - 1].encode('utf_16_le')) // 2
+                c.setPosition(b.position() + qchar_offset)
+                # escape to in front of what might be the middle of a composed glyph
+                c.movePosition(QTextCursor.NextCharacter)
+                c.movePosition(QTextCursor.PreviousCharacter)
+            else:
+                c.setPosition(b.position())
+                c.movePosition(QTextCursor.EndOfBlock)
         else:
-            self._cursor = None
+            c.movePosition(QTextCursor.End)
 
     def unbind(self):
         """Called when previously "bound" document is closed."""


### PR DESCRIPTION
This corrects the cursor position when jumping from an error message in the log to the referenced place in the code.

If column numbers ever did start with 0 in LilyPond, they no longer do, so changed that comment (line 117).

QTextCursor.setPosition() works on QChar (16-bit) offsets and is thus not compatible with supplementary plane characters.
QTextCursor.movePosition() with MoveOperation NextCharacter almost works, but jumps over composed characters as one, whereas LilyPond counts each codepoint.
So the strategy is counting characters via Python str, as with determining correct cursor position in status bar.

The handling of column number overrun (lines 156-158) may seem overcomplicated vs. just taking a minimum of the qchar_offset and the block length(), but QTextBlock.length() "includes all formatting characters, for example, newline", and I don't know if it's guaranteed to only and always be exactly one LF character.  This approach avoids needing that guarantee.

Realized that arbitrarily setting position of cursor can result in it being in the middle of a composed glyph, or, if the block changes during the offset calculation, in the middle of a supplementary plane codepoint.  Either way leads to undesirable behavior when input resumes, e.g. moving a combining character to a different base or splitting a surrogate pair.  That's what line 155 takes care of.  And yes, the order (next, then previous) matters, because we want the cursor just in front of the offending glyph, not after it.

This works on my end.  Tested with this input (test.ly)
```
\version "2.22.2"
\header {
) % <-- first of this line
  title = "Testing Error Jumps" % no error here; last of next line -->
  subtitle = "in Frescobaldi")
  source = "AAAAAAAAA" ) % ASCII range
  composer = "ÅÅÅÅÅÅÅÅÅÅÅ") % composed character
  style = "ÅÅÅÅÅÅÅÅÅ" ) % precomposed character
  meter = "𐌴𐌴𐌴𐌴𐌴𐌴𐌴𐌴𐌴𐌴𐌴𐌴𐌴𐌴𐌴𐌴𐌴𐌴𐌴𐌴𐌴") % supplementary plane letter
  poet = "😊😊😊😊😊😊😊😊😊" ) % supplementary plane emoji
  copyright = "❤❤❤❤❤❤❤❤❤❤") % basic plane emoji
}
\score {
  << a >>
}% this is the end of the file.
```
If you try this, you'll notice there are still various display/formatting problems with the supplementary plane characters, but the cursor goes to the right place.

Also tested out-of-bounds behavior by temporary hard-coding of line and column numbers.
