### PR TITLE
Correct default of go to line number

### DIFF
--- a/frescobaldi_app/mainwindow.py
+++ b/frescobaldi_app/mainwindow.py
@@ -975,9 +975,7 @@ class MainWindow(QMainWindow):
         line_count = self.currentDocument().blockCount()
         view = self.currentView()
         cur = view.textCursor()
-        current_block = cur.block()
-        current_line = current_block.firstLineNumber()
-        char_pos = cur.position() - current_block.position()
+        current_line = cur.blockNumber() + 1
         loc_pos = view.cursorRect(cur).bottomLeft()
         pos = view.viewport().mapToGlobal(loc_pos)
 
@@ -992,14 +990,13 @@ class MainWindow(QMainWindow):
         dlg_result = dlg.exec()
         if dlg_result:
             line = dlg.intValue()
-            cur = QTextCursor(self.currentDocument().findBlockByNumber(line - 1))
-            new_block = cur.block()
-            if new_block.length() > char_pos:
-                cur.setPosition(cur.position() + char_pos)
-            else:
-                cur.setPosition(cur.position() + new_block.length() - 1)
-            view.setTextCursor(cur)
-            view.centerCursor()
+            if line != current_line:
+                cur = QTextCursor(self.currentDocument().findBlockByNumber(line - 1))
+                line_text = cur.block().text()
+                indent = len(line_text) - len(line_text.lstrip(' \t'))
+                cur.movePosition(QTextCursor.NextCharacter, QTextCursor.MoveAnchor, indent)
+                view.setTextCursor(cur)
+                view.centerCursor()
 
     def selectFullLinesUp(self):
         """Select lines upwards, selecting full lines."""


### PR DESCRIPTION
Currently, the "Goto Line..." (menu) or "Goto Line Number" (dialog) feature (Ctrl+Alt+G) defaults to the line above the current line.  This fixes the off-by-one error, apparently caused by someone thinking that `.firstLineNumber()` does something other than what it actually does.

It also modifies the behavior as follows:
- Previously, the cursor was arbitrarily put in the same "position" relative to the beginning of the block.
- This change puts the cursor at the beginning of the line, but after any indentation.

Rationale:  If you're jumping by line number to a completely different place in your code, it seems doubtful that you care about being at the same column position.  The context has changed, so that isn't relevant.  It's better that you be able to simply find your cursor at the beginning instead of some irrelevant spot in that line you just jumped to.  But even if the intended behavior is to go to the same column position, that's not what the current code does; it goes to the same `.positionInBlock()` (or using old functions, `cur.position() - current_block.position()`) which is measured in `QChar`s, not in characters.  This makes the jump liable to end up in the middle of a composed glyph or even the middle of a surrogate pair, which is invisible to the user and leads to unindended consequences if you start editing there.

I think the message texts for this feature need to change, since "goto" is not a word in English and it doesn't match the wording of other commands on the same menu, e.g. "Go to previous position", but that can be part of a separate language clean-up job.
FWIW, I suggest:
(menu) "Go to line..."
(dialog) "Go to line number (1-{num}):"
