### PR TITLE
Tiny update in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Features:
 - Experimental export to MusicXML
 - Modern user interface with configurable colors, fonts and keyboard shortcuts
 - Translated into: Dutch, English, French, German, Italian, Swedish, Czech,
-  Russian, Spanish, Galician, Turkish, Polish, Brazilian and Ukrainian.
+  Russian, Spanish, Galician, Turkish, Polish, Brazilian, Ukrainian, and Japanese.
 
 Music functions:
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Features:
 - Experimental export to MusicXML
 - Modern user interface with configurable colors, fonts and keyboard shortcuts
 - Translated into: Dutch, English, French, German, Italian, Swedish, Czech,
-  Russian, Spanish, Galician, Turkish, Polish, Brazilian, Ukrainian, and Japanese.
+  Russian, Spanish, Galician, Turkish, Polish, Brazilian, Ukrainian, 
+  Traditional Chinese, Simplified Chinese and Japanese.
 
 Music functions:
 


### PR DESCRIPTION
Japanese has been added at the last of "Translated into:...". I'm not sure about the appropriate order of the languages.