### PR TITLE
Improve selection behavior in list of snippets

### DIFF
--- a/frescobaldi_app/snippet/edit.py
+++ b/frescobaldi_app/snippet/edit.py
@@ -186,7 +186,7 @@ class Edit(QDialog):
             self.text.toPlainText(), self.titleEntry.text())
         # set snippet current in the editor that called us
         self.parent().treeView.selectionModel().setCurrentIndex(
-            index, QItemSelectionModel.SelectCurrent | QItemSelectionModel.Rows)
+            index, QItemSelectionModel.Clear | QItemSelectionModel.SelectCurrent | QItemSelectionModel.Rows)
         #remove the shortcuts conflicts
         self.actionManager().removeShortcuts(self.shortcuts())
         self.parent().treeView.update()

--- a/frescobaldi_app/snippet/widget.py
+++ b/frescobaldi_app/snippet/widget.py
@@ -358,14 +358,17 @@ class Widget(QWidget):
             except ValueError:
                 fvar = text[1:].strip()
                 fhide = lambda v: not v.get(fvar)
+        self.treeView.selectionModel().clear()
+        index = None
         for row in range(self.treeView.model().rowCount()):
             name = self.treeView.model().names()[row]
             nameid = snippets.get(name).variables.get('name', '')
             if filterVars:
                 hide = fhide(snippets.get(name).variables)
-            elif nameid == text:
-                i = self.treeView.model().createIndex(row, 0)
-                self.treeView.selectionModel().setCurrentIndex(i, QItemSelectionModel.SelectCurrent | QItemSelectionModel.Rows)
+            elif text and nameid == text:
+                index = self.treeView.model().createIndex(row, 0)
+                self.treeView.selectionModel().setCurrentIndex(
+                    index, QItemSelectionModel.SelectCurrent | QItemSelectionModel.Rows)
                 hide = False
             elif nameid.lower().startswith(ltext):
                 hide = False
@@ -375,6 +378,7 @@ class Widget(QWidget):
                 hide = True
             self.treeView.setRowHidden(row, QModelIndex(), hide)
         self.updateText()
+        self.treeView.scrollTo(index if index else self.treeView.model().createIndex(0,0))
 
     def updateText(self):
         """Called when the current snippet changes."""


### PR DESCRIPTION
This fixes a few problems with the snippets list.

1) Currently, if you have a snippet selected, then add a new one, both what was selected and the new one will be selected.  This isn't always obvious to a user, because they could be in a totally different place in the list.  If the user then deletes the snippet he just made, he'll also be deleting what else just happened to be selected before he made a new snippet.  This is fixed by clearing the selection and only selecting the new snippet.

2) Currently, the `updateFilter` method selects the last item in the list that has no `nameid` whenever the search box becomes empty.  This is because `"" == ""`, which is an insufficient reason to select a snippet from the search.  This is fixed by testing for empty search `text`.

3) Currently, the `QTreeView` list of snippets maintains previous selections while searching.  This leads to the odd behavior of snippets leaving the list and coming back onto the list already selected.  Or, it can mean that a snippet stays selected even when you've clearly typed something that doesn't match its `nameid`, simply because some previous state of the search box text did match a one or two letter `nameid`.  These things are fixed by clearing the selection state before the for loop in `updateFilter`.

4) Currently, the list of snippets ends up scrolled to relatively random places.  This is fixed by scrolling to the first item on the list when the search box makes no selection, or to the last (usually only one) snippet selected by the search.  This provides a much more intuitive and dependable behavior than the user wondering why sometimes it scrolls him down and sometimes it doesn't.  If he wants to select something manually, it's always going to be with the down arrow or page down instead of having to check whether there are also results hidden above the current top result.

Notes:

I'm not really sure why `QItemSelectionModel.Clear` is needed in `edit.py` to avoid multiple selection but isn't needed in `widget.py` to avoid multiple selection.  (It probably wouldn't hurt to add it, but I didn't because it works without it in `widget.py`.)  Whatever the reason, I've tested it and it works as expected for me.
