### PR TITLE
Set default remote URLs to browse LilyPond documentation

### DIFF
--- a/frescobaldi_app/appinfo.py
+++ b/frescobaldi_app/appinfo.py
@@ -45,3 +45,7 @@ desktop_file_name = "org.frescobaldi.Frescobaldi.desktop"
 # required versions of important dependencies
 required_python_version = (3, 8)
 required_python_ly_version = (0, 9, 4)
+
+# LilyPond doc URLs to be used in lilydoc/manager.py
+lilydoc_stable = "http://lilypond.org/doc/v2.24"
+lilydoc_development = "http://lilypond.org/doc/v2.25"

--- a/frescobaldi_app/lilydoc/manager.py
+++ b/frescobaldi_app/lilydoc/manager.py
@@ -27,6 +27,7 @@ import os
 from PyQt5.QtCore import QSettings, QUrl
 
 import app
+import appinfo
 import util
 import signals
 import qsettings
@@ -127,7 +128,7 @@ def urls():
     # split in local and non-local ones (local are preferred)
     user_prefixes = []
     local = []
-    remote = []
+    remote = [appinfo.lilydoc_stable, appinfo.lilydoc_development]
     for p in user_paths:
         user_prefixes.append(p) if os.path.isdir(p) else remote.append(p)
     remote.sort(key=util.naturalsort)

--- a/frescobaldi_app/userguide/prefs_lilydoc.md
+++ b/frescobaldi_app/userguide/prefs_lilydoc.md
@@ -1,6 +1,9 @@
 === LilyPond Documentation ===
 
-Here you can add local paths or URLs pointing to LilyPond documentation.
+Here you can add local paths or remote URLs pointing to LilyPond documentation.
+
+The URLs to the latest stable and development LilyPond manuals are already
+set by default for user convenience.
 
 == Local path ==
 


### PR DESCRIPTION
See discussion in #1163