### PR TITLE
Release Frescobaldi 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Frescobaldi project are documented in this file.
 
 ## [Unreleased]
 
+
+
+## [3.3.0] - 2023-03-26
+
 ### Added
 
 - Add option to format on save (#1473)
@@ -1586,7 +1590,8 @@ README-translations.
 
 * Initial release.
 
-[unreleased]: https://github.com/frescobaldi/frescobaldi/compare/v3.2...master
+[unreleased]: https://github.com/frescobaldi/frescobaldi/compare/v3.3.0...master
+[3.3.0]: https://github.com/frescobaldi/frescobaldi/compare/v3.2...v3.3.0
 [3.2]: https://github.com/frescobaldi/frescobaldi/compare/v3.1.3...v3.2
 [3.1.3]: https://github.com/frescobaldi/frescobaldi/compare/v3.1.2...v3.1.3
 [3.1.2]: https://github.com/frescobaldi/frescobaldi/compare/v3.1.1...v3.1.2

--- a/README-development
+++ b/README-development
@@ -256,8 +256,9 @@ of testing and development, you don't even need to install Python at all.
 New release checklist
 =====================
 
-Checklist before uploading a new release:
+Checklist before making a new release:
 
-- Update CHANGELOG.md.
-- Add the new release tag in linux/org.frescobaldi.Frescobaldi.metainfo.xml.in.
+- Bump the version in `frescobaldi_app/appinfo.py`.
+- Add the release date in `CHANGELOG.md` and `linux/org.frescobaldi.Frescobaldi.metainfo.xml.in`.
+- Update the list of contributors in `frescobaldi_app/userguide/credits.md`.
 

--- a/frescobaldi_app/appinfo.py
+++ b/frescobaldi_app/appinfo.py
@@ -25,7 +25,7 @@ Information about the Frescobaldi application.
 
 # these variables are also used by the distutils setup
 name = "frescobaldi"
-version = "3.2"
+version = "3.3.0"
 extension_api = "0.9.0"
 description = "LilyPond Music Editor"
 long_description = \

--- a/frescobaldi_app/userguide/credits.md
+++ b/frescobaldi_app/userguide/credits.md
@@ -6,10 +6,16 @@ The Music View is powered by the {poppler} library by {authors} and others.
 
 Most of the bundled icons are created by {tango}.
 
-The following people contributed to {appname}:
+The following people contributed to {appname} (in alphabetical order):
+
+!Jean Abou Samra
+: Bug and compatibility fixes, miscellaneous
 
 !Wilbert Berendsen:
 : Main author and core developer
+
+!@mr-bronson
+: Encoding-related fixes and other improvements
 
 !Christopher Bryan:
 : !_(Modal Transpose)_
@@ -21,6 +27,13 @@ The following people contributed to {appname}:
 
 !Richard Cognot:
 : Kinetic Scrolling for the Music View
+
+!Benjamin Johnson:
+: !_(Score Wizard improvements)_,
+  _(Score Wizard From Current Document)_
+
+!Jörg Hoffmann
+: Windows installers
 
 !Marnen Laibow-Koser:
 : Homebrew formula for Mac OS X
@@ -50,10 +63,6 @@ The following people contributed to {appname}:
 !Alex Schreiber:
 : Relative mode for MIDI capturing
 
-!Benjamin Johnson:
-: !_(Score Wizard improvements)_,
-  _(Score Wizard From Current Document)_
-
 
 {appname} is translated into the following languages:
 
@@ -61,14 +70,20 @@ The following people contributed to {appname}:
 : !Wilbert Berendsen
 
 {lang_fr}:
-:  !Raphaël Doursenaud,
+:  !Rémy Claverie,
     Denis Bitouzé,
-    Philippe Massart,
-    Valentin Villenave,
-    Yann Collette,
     David Bouriaud,
+    Richard Cognot,
+    Yann Collette,
+    Raphaël Doursenaud,
+    Emmanuel Franquemagne,
+    Raphaël Hardy,
     Ryan Kavanagh,
-    Richard Cognot
+    Nicolas Lehembre,
+    Philippe Massart,
+    Olivier Miakinen,
+    Martial Rameaux,
+    Valentin Villenave
 
 {lang_tr}:
 :  !Server ACİM

--- a/linux/org.frescobaldi.Frescobaldi.metainfo.xml.in
+++ b/linux/org.frescobaldi.Frescobaldi.metainfo.xml.in
@@ -67,6 +67,7 @@
   <translation type="gettext">frescobaldi</translation>
 
   <releases>
+    <release version="3.3.0" date="2023-03-26" />
     <release version="3.2"   date="2022-05-05" />
     <release version="3.1.3" date="2020-12-26" />
     <release version="3.1.2" date="2020-04-13" />


### PR DESCRIPTION
I set 21st of March as a target release date. We thought that 3.3.0 would have come out last Christmas and instead we had to wait for Spring! :-)

Please check if I missed anything.
I didn't dare to update the `credits.md` file, but I'm sure that Jean should be put there. @jeanas feel free to add yourself there and describe what you did; you can add a commit on top of mine.

I've added @19joho66 who usually makes the Windows package.