### PR TITLE
fix running Python tools from app bundle on Mac

### DIFF
--- a/frescobaldi_app/convert_ly.py
+++ b/frescobaldi_app/convert_ly.py
@@ -25,6 +25,7 @@ Updates a document using convert-ly.
 import difflib
 import textwrap
 import os
+import sys
 
 from PyQt5.QtCore import QSettings, QSize
 from PyQt5.QtGui import QFont
@@ -222,6 +223,11 @@ class Dialog(QDialog):
             j.environment['LC_MESSAGES'] = 'C'
         else:
             j.environment.pop('LC_MESSAGES', None)
+        if sys.platform.startswith('darwin'):
+            import macosx
+            if macosx.inside_app_bundle():
+                j.environment['PYTHONPATH'] = None
+                j.environment['PYTHONHOME'] = None
 
         j.done.connect(self.slotJobDone)
         app.job_queue().add_job(j, 'generic')

--- a/frescobaldi_app/file_import/toly_dialog.py
+++ b/frescobaldi_app/file_import/toly_dialog.py
@@ -23,6 +23,7 @@ Generic import dialog. Presuppose a child instance for the specific import.
 
 
 import os
+import sys
 
 from PyQt5.QtCore import Qt
 
@@ -153,6 +154,11 @@ class ToLyDialog(QDialog):
             directory=os.path.dirname(self._input),
             encoding='utf-8')
         j._output_file = output
+        if sys.platform.startswith('darwin'):
+            import macosx
+            if macosx.inside_app_bundle():
+                j.environment['PYTHONPATH'] = None
+                j.environment['PYTHONHOME'] = None
 
     def get_post_settings(self):
         """Returns settings in the post import tab."""


### PR DESCRIPTION
Application bundles overwrite several environment variables. In particular they (at least those generated by py2app) define PYTHONPATH and PYTHONHOME to the Resource directory inside the bundle, breaking the Python module search.

This PR should fix #1395.