### PR TITLE
Blank staff in wizard (fix #1139)

### DIFF
--- a/frescobaldi_app/scorewiz/build.py
+++ b/frescobaldi_app/scorewiz/build.py
@@ -132,6 +132,10 @@ class PartData(object):
             ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2), ly.dom.Transposition(s))
         ly.dom.LineComment(_("Music follows here."), s)
         ly.dom.BlankLine(s)
+        num = self.scoreProperties.blankStaff.value()
+        if num:
+            ly.dom.Text(r"\repeat unfold {num} {{ s1 \break }}".format(num=num), s)
+            ly.dom.BlankLine(s)
         return a
 
 

--- a/frescobaldi_app/scorewiz/scoreproperties.py
+++ b/frescobaldi_app/scorewiz/scoreproperties.py
@@ -67,7 +67,7 @@ class ScoreProperties(object):
         self.translateKeySignatureWidget()
         self.translateTimeSignatureWidget()
         self.translatePickupWidget()
-        self.tranlateMetronomeWidget()
+        self.translateMetronomeWidget()
         self.translateTempoWidget()
         self.translateBlankStaffWidget()
 
@@ -227,7 +227,7 @@ class ScoreProperties(object):
         grid.addWidget(self.metronomeRound, 1, 1)
         layout.addLayout(grid)
 
-    def tranlateMetronomeWidget(self):
+    def translateMetronomeWidget(self):
         self.metronomeLabel.setText(_("Metronome mark:"))
         self.metronomeRound.setText(_("Round tap tempo value"))
         self.metronomeRound.setToolTip(_(

--- a/frescobaldi_app/scorewiz/scoreproperties.py
+++ b/frescobaldi_app/scorewiz/scoreproperties.py
@@ -33,7 +33,7 @@ import re
 from PyQt5.QtCore import QSize, Qt
 from PyQt5.QtGui import QIntValidator
 from PyQt5.QtWidgets import (
-    QCheckBox, QComboBox, QGridLayout, QHBoxLayout, QLabel, QLineEdit)
+    QCheckBox, QComboBox, QGridLayout, QHBoxLayout, QLabel, QLineEdit, QSpinBox)
 
 import ly.dom
 import completionmodel
@@ -52,6 +52,7 @@ class ScoreProperties(object):
         self.createPickupWidget()
         self.createMetronomeWidget()
         self.createTempoWidget()
+        self.createBlankStaffWidget()
 
     def layoutWidgets(self, layout):
         """Adds all widgets to a vertical layout."""
@@ -60,6 +61,7 @@ class ScoreProperties(object):
         self.layoutPickupWidget(layout)
         self.layoutMetronomeWidget(layout)
         self.layoutTempoWidget(layout)
+        self.layoutBlankStaffWidget(layout)
 
     def translateWidgets(self):
         self.translateKeySignatureWidget()
@@ -67,6 +69,7 @@ class ScoreProperties(object):
         self.translatePickupWidget()
         self.tranlateMetronomeWidget()
         self.translateTempoWidget()
+        self.translateBlankStaffWidget()
 
     def ly(self, node, builder):
         """Adds appropriate LilyPond command nodes to the parent node.
@@ -289,6 +292,26 @@ class ScoreProperties(object):
         dur = durations[self.metronomeNote.currentIndex()]
         val = self.metronomeValue.currentText() or '60'
         return ly.dom.Tempo(dur, val, node)
+
+    # Blank staff
+    def createBlankStaffWidget(self):
+        self.blankStaffLabel = QLabel()
+        self.blankStaff = QSpinBox()
+        self.blankStaff.setRange(0, 10000)
+        self.blankStaffLabel.setBuddy(self.blankStaff)
+
+    def layoutBlankStaffWidget(self, layout):
+        box = QHBoxLayout()
+        box.addWidget(self.blankStaffLabel)
+        box.addWidget(self.blankStaff)
+        layout.addLayout(box)
+
+    def translateBlankStaffWidget(self):
+        self.blankStaffLabel.setText(_("Blank staff lines:"))
+        self.blankStaff.setSpecialValueText(_("no blank staff lines", "Disabled"))
+        self.blankStaff.setToolTip(_(
+            "Add blank staff lines along with the current configuration."
+            ))
 
 
 def metronomeValues():

--- a/frescobaldi_app/scorewiz/settings.py
+++ b/frescobaldi_app/scorewiz/settings.py
@@ -56,6 +56,7 @@ class SettingsWidget(QWidget):
         self.scoreProperties.keyNote.setCurrentIndex(0)
         self.scoreProperties.keyMode.setCurrentIndex(0)
         self.scoreProperties.pickup.setCurrentIndex(0)
+        self.scoreProperties.blankStaff.setValue(0)
 
 
 class ScoreProperties(QGroupBox, scoreproperties.ScoreProperties):


### PR DESCRIPTION
Hi,
This PR adds a new option in the score wizard to create blank staff with the given configuration.

Fixes #1139 

It generates this kind of code :
```lilypond
flute = \relative do'' {
  \global
  % Music follows here.
  
  \repeat unfold 7 { s1 \break }
  
}
```

![image](https://github.com/frescobaldi/frescobaldi/assets/506348/ca4cf9be-3cdb-4ae7-ae44-2cb830ee095e)
