### PR TITLE
Preferences: Extensions: don't crash on missing config widget

### DIFF
--- a/frescobaldi_app/preferences/extensions.py
+++ b/frescobaldi_app/preferences/extensions.py
@@ -363,6 +363,7 @@ class Config(preferences.Group):
             # skip non-loaded extensions
             if ext:
                 widget = ext.config_widget(self)
-                widget.load_settings()
+                if widget:
+                    widget.load_settings()
             self._widgets[extension] = widget or None
         return widget


### PR DESCRIPTION
`Extension.config_widget()` may return None, as specified in its docstring, but the code calling it wasn't handling such cases

resulting in

```
Traceback (most recent call last):
  File "/home/igneus/apps/frescobaldi/frescobaldi_app/preferences/extensions.py", line 275, in selection_changed
    config.show_extension(name)
  File "/home/igneus/apps/frescobaldi/frescobaldi_app/preferences/extensions.py", line 352, in show_extension
    widget = self.widget(name) or self.empty_widget
             ^^^^^^^^^^^^^^^^^
  File "/home/igneus/apps/frescobaldi/frescobaldi_app/preferences/extensions.py", line 366, in widget
    widget.load_settings()
    ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'load_settings'
```

when an extension lacks a config widget and its entry in `Preferences > Extensions` is clicked