### PR TITLE
Fix misspelled LilyPond option

### DIFF
--- a/frescobaldi_app/engrave/custom.py
+++ b/frescobaldi_app/engrave/custom.py
@@ -174,7 +174,7 @@ class Dialog(QDialog):
         elif self.modeCombo.currentIndex() == 2: # incipit mode
             job_class = job.lilypond.LilyPondJob
             d_options['preview'] = True
-            d_options['print_pages'] = False
+            d_options['print-pages'] = False
         else:                                    # debug mode
             job_class = job.lilypond.LayoutControlJob
             args = panelmanager.manager(


### PR DESCRIPTION
I've noticed this typo while running LilyPond in custom mode using the "first system only" option.
And I saw in the log:

> warning: no such internal option: no-print_pages

I don't know if it's ever been print_pages. I guess it was a typo.
