### PR TITLE
remote: don't crash when --line is used without --column

### DIFF
--- a/frescobaldi_app/remote/api.py
+++ b/frescobaldi_app/remote/api.py
@@ -63,7 +63,7 @@ class Remote(object):
                 self.write(b'open ' + u.toEncoded() + b'\n')
             self.write(b'set_current ' + u.toEncoded() + b'\n')
             if args.line is not None:
-                self.write('set_cursor {0} {1}\n'.format(args.line, args.column).encode('utf-8'))
+                self.write('set_cursor {0} {1}\n'.format(args.line, args.column or 0).encode('utf-8'))
         self.write(b'activate_window\n')
 
 


### PR DESCRIPTION
```gherkin
Feature: --line (without --column)

Scenario: Opening file in a new editor instance
  When no Frescobaldi instance is running
  And a command like "$ frescobaldi --line 5 myfile.ly" is executed
  Then the application starts
  And opens the specified file
  And places the cursor on line 5, column 0.

Scenario: Opening file in a running editor instance
  When a Frescobaldi instance is already running
  And the same command is executed
  Then the running instance opens the specified file
  # bug:
  But the specified line is not respected
  And an error window pops up:
    """
    Traceback (most recent call last):
      File "/home/igneus/apps/frescobaldi/frescobaldi_app/remote/api.py", line 91, in read
        self.command(self.data[end:pos])
      File "/home/igneus/apps/frescobaldi/frescobaldi_app/remote/api.py", line 126, in command
        line, column = map(int, args)
        ^^^^^^^^^^^^
    ValueError: invalid literal for int() with base 10: b'None'
    """
```

In the past this definitely did work without error. (For a long time I was out of sync with latest Frescobaldi development, having frozen in time with contents of the master branch of July 2017.)

The proposed change makes the behaviour of `--line` without `--column` once again consistent for both starting a new instance and calling an already running one.