### PR TITLE
Fix column inconsistency

### DIFF
--- a/frescobaldi_app/remote/api.py
+++ b/frescobaldi_app/remote/api.py
@@ -125,7 +125,7 @@ class Incoming(object):
         elif cmd == b'set_cursor':
             line, column = map(int, args)
             cursor = win.textCursor()
-            pos = cursor.document().findBlockByNumber(line - 1).position() + column
+            pos = cursor.document().findBlockByNumber(line - 1).position() + (column - 1)
             cursor.setPosition(pos)
             win.currentView().setTextCursor(cursor)
         elif cmd == b'bye':

--- a/frescobaldi_app/remote/api.py
+++ b/frescobaldi_app/remote/api.py
@@ -63,7 +63,7 @@ class Remote(object):
                 self.write(b'open ' + u.toEncoded() + b'\n')
             self.write(b'set_current ' + u.toEncoded() + b'\n')
             if args.line is not None:
-                self.write('set_cursor {0} {1}\n'.format(args.line, args.column or 0).encode('utf-8'))
+                self.write('set_cursor {0} {1}\n'.format(args.line, args.column or 1).encode('utf-8'))
         self.write(b'activate_window\n')
 
 


### PR DESCRIPTION
This

- fixes a new bug introduced in my recent PR #1662 (`--column` values are 1-based, not 0-based, the default value wasn't taking this in account)
- addresses another bug pre-existent in the code base: different internal APIs are used for cursor position setting when starting a new Frescobaldi instance vs. when processing a remote `set_cursor` command. The latter internal API expects 0-based values, which was not accounted for in case of `--column`, resulting in inconsistent behaviour of `--column`