### PR TITLE
musicview: fix crash in link context menu

### DIFF
--- a/frescobaldi_app/musicview/contextmenu.py
+++ b/frescobaldi_app/musicview/contextmenu.py
@@ -58,12 +58,12 @@ def show(position, panel, link, cursor):
         @a.triggered.connect
         def open_in_browser():
             import helpers
-            helpers.openUrl(QUrl(link.url()))
+            helpers.openUrl(QUrl(link.url))
 
         a = m.addAction(icons.get("edit-copy"), _("Copy &Link"))
         @a.triggered.connect
         def copy_link():
-            QApplication.clipboard().setText(link.url())
+            QApplication.clipboard().setText(link.url)
 
     # no actions yet? insert Fit Width/Height
     if not m.actions():


### PR DESCRIPTION
How to replicate the issue:

- open any document whose pdf contains a link (e.g. any document using the unmodified default layout has a link to the LilyPond homepage in the tagline)
- right-click the link
- from the context menu select either "Open Link in New Window" or "Copy Link" (both actions are affected)
- instead of performing the selected action the editor presents a crash report window

(The issue seems to be around since about c5ed67151.)