### PR TITLE
Use standard clefs for guitar, bass guitar, and double bass (fixes #1571)

### DIFF
--- a/frescobaldi_app/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi_app/scorewiz/parts/plucked_strings.py
@@ -201,6 +201,7 @@ class TablaturePart(_base.Part):
             if self.tabFormat:
                 tabstaff.getWith()['tablatureFormat'] = ly.dom.Scheme(self.tabFormat)
             self.setTunings(tabstaff)
+            builder.setMidiInstrument(tabstaff, self.midiInstrument)
             sim = ly.dom.Simr(tabstaff)
             if numVoices == 1:
                 ly.dom.Identifier(assignments[0].name, sim)
@@ -215,7 +216,6 @@ class TablaturePart(_base.Part):
             p = staff
         elif staffType == 1:
             # only a TabStaff
-            builder.setMidiInstrument(tabstaff, self.midiInstrument)
             p = tabstaff
         else:
             # both TabStaff and normal staff

--- a/frescobaldi_app/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi_app/scorewiz/parts/plucked_strings.py
@@ -334,7 +334,7 @@ class Guitar(TablaturePart):
         return _("abbreviation for Guitar", "Gt.")
 
     midiInstrument = 'acoustic guitar (nylon)'
-    clef = "treble_8"
+    soundingOctave = -1
     tunings = (
         ('guitar-tuning', lambda: _("Guitar tuning")),
         ('guitar-seven-string-tuning', lambda: _("Guitar seven-string tuning")),

--- a/frescobaldi_app/scorewiz/parts/strings.py
+++ b/frescobaldi_app/scorewiz/parts/strings.py
@@ -82,8 +82,9 @@ class Contrabass(StringPart):
         return _("abbreviation for Contrabass", "Cb.")
 
     midiInstrument = 'contrabass'
-    clef = 'bass_8'
-    octave = -2
+    clef = 'bass'
+    octave = -1
+    transposition = (-1, 0, 0)
 
 
 class BassoContinuo(Cello):


### PR DESCRIPTION
This PR corrects one of my previous submissions. I have learned that 8vb clefs not considered standard anywhere for either bass guitar or double bass, so rather than add them to the latter I should have removed them from the former. (I had always wondered why Frescobaldi used them myself, but assumed there was a reason it was programmed that way.)

From what I understand, the 8vb clef _is_ generally considered acceptable for guitar, but standard treble clef remains the more established convention. I thus changed it for consistency with the other octave-transposing instruments -- not just the basses but also the recorder family, pitched percussion, and so on. That said, I'm not as familiar with current practices for guitar notation, so feel free to skip or revert that one if I'm off the mark.