### PR TITLE
Improve handling of transposing instruments in the Score Wizard (fixes #1733)

### DIFF
--- a/frescobaldi_app/scorewiz/build.py
+++ b/frescobaldi_app/scorewiz/build.py
@@ -23,7 +23,6 @@ Builds the LilyPond score from the settings in the Score Wizard.
 
 
 import collections
-import fractions
 import re
 
 import ly.dom
@@ -127,11 +126,6 @@ class PartData:
         ly.dom.Pitch(octave, 0, 0, stub)
         s = ly.dom.Seq(stub)
         ly.dom.Identifier(self.globalName, s).after = 1
-        if transposition is not None:
-            toct, tnote, talter = transposition
-            # this corrects the sounding pitch for MIDI after
-            # the written pitch is transposed by SingleVoicePart.build()
-            ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2), ly.dom.Transposition(s))
         ly.dom.LineComment(_("Music follows here."), s)
         ly.dom.BlankLine(s)
         return a

--- a/frescobaldi_app/scorewiz/parts/_base.py
+++ b/frescobaldi_app/scorewiz/parts/_base.py
@@ -117,11 +117,10 @@ class SingleVoicePart(Part):
             toct, tnote, talter = self.transposition
             # \transposition sets the sounding pitch for written c'
             ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2), ly.dom.Transposition(seq))
-            if tnote or talter:
-                stub = ly.dom.Command('transpose', seq)
-                ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2), stub)
-                ly.dom.Pitch(0, 0, 0, stub)
-                seq = ly.dom.Seqr(stub)
+            stub = ly.dom.Command('transpose', seq)
+            ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2), stub)
+            ly.dom.Pitch(0, 0, 0, stub)
+            seq = ly.dom.Seqr(stub)
         ly.dom.Identifier(a.name, seq)
         data.nodes.append(staff)
 

--- a/frescobaldi_app/scorewiz/parts/_base.py
+++ b/frescobaldi_app/scorewiz/parts/_base.py
@@ -109,15 +109,18 @@ class SingleVoicePart(Part):
         if self.clef:
             ly.dom.Clef(self.clef, seq)
         if self.transposition is not None:
+            # Transpose music from concert to written pitch.
+            # Note that \transpose affects both printed and MIDI output,
+            # while \transposition affects only the latter, so we use
+            # \transposition to restore the correct sounding pitch after
+            # \transpose-ing. (Well, technically before, but it's commutative.)
             toct, tnote, talter = self.transposition
+            # \transposition sets the sounding pitch for written c'
+            ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2), ly.dom.Transposition(seq))
             if tnote or talter:
-                # use the appropriate key for non-octave transpositions
                 stub = ly.dom.Command('transpose', seq)
-                # the sounding pitch from PartData.assignMusic()...
                 ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2), stub)
-                # ...becomes our written middle C
                 ly.dom.Pitch(0, 0, 0, stub)
-                # place the music within our \transpose block
                 seq = ly.dom.Seqr(stub)
         ly.dom.Identifier(a.name, seq)
         data.nodes.append(staff)

--- a/frescobaldi_app/scorewiz/parts/brass.py
+++ b/frescobaldi_app/scorewiz/parts/brass.py
@@ -168,8 +168,8 @@ class BassTuba(BrassPart):
 
     midiInstrument = 'tuba'
     clef = 'bass'
-    octave = -1
-    transposition = (-2, 0, 0)
+    octave = -2
+    transposition = (-1, 0, 0)
 
 
 register(

--- a/frescobaldi_app/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi_app/scorewiz/parts/plucked_strings.py
@@ -182,6 +182,7 @@ class TablaturePart(_base.Part):
             if self.tabFormat:
                 tabstaff.getWith()['tablatureFormat'] = ly.dom.Scheme(self.tabFormat)
             self.setTunings(tabstaff)
+            builder.setMidiInstrument(tabstaff, self.midiInstrument)
             sim = ly.dom.Simr(tabstaff)
             if numVoices == 1:
                 ly.dom.Identifier(assignments[0].name, sim)
@@ -196,7 +197,6 @@ class TablaturePart(_base.Part):
             p = staff
         elif staffType == 1:
             # only a TabStaff
-            builder.setMidiInstrument(tabstaff, self.midiInstrument)
             p = tabstaff
         else:
             # both TabStaff and normal staff

--- a/frescobaldi_app/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi_app/scorewiz/parts/plucked_strings.py
@@ -324,7 +324,7 @@ class Guitar(TablaturePart):
         return _("abbreviation for Guitar", "Gt.")
 
     midiInstrument = 'acoustic guitar (nylon)'
-    clef = "treble_8"
+    transposition = (-1, 0, 0)
     tunings = (
         ('guitar-tuning', lambda: _("Guitar tuning")),
         ('guitar-seven-string-tuning', lambda: _("Guitar seven-string tuning")),

--- a/frescobaldi_app/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi_app/scorewiz/parts/plucked_strings.py
@@ -22,6 +22,8 @@ Plucked string part types.
 """
 
 
+import fractions
+
 from PyQt5.QtWidgets import (
     QCheckBox, QComboBox, QCompleter, QGridLayout, QHBoxLayout, QLabel,
     QLineEdit, QSpinBox,
@@ -165,6 +167,13 @@ class TablaturePart(_base.Part):
             seq = ly.dom.Seqr(staff)
             if self.clef:
                 ly.dom.Clef(self.clef, seq)
+            if self.transposition is not None:
+                toct, tnote, talter = self.transposition
+                ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2), ly.dom.Transposition(seq))
+                stub = ly.dom.Command('transpose', seq)
+                ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2), stub)
+                ly.dom.Pitch(0, 0, 0, stub)
+                seq = ly.dom.Seqr(stub)
             mus = ly.dom.Simr(seq)
             for a in assignments[:-1]:
                 ly.dom.Identifier(a.name, mus)
@@ -389,8 +398,9 @@ class AcousticBass(TablaturePart):
         return _("abbreviation for Acoustic bass", "A.Bs.") #FIXME
 
     midiInstrument = 'acoustic bass'
-    clef = 'bass_8'
+    clef = 'bass'
     octave = -2
+    transposition = (-1, 0, 0)
     tunings = (
         ('bass-tuning', lambda: _("Bass tuning")),
         ('bass-four-string-tuning', lambda: _("Four-string bass tuning")),

--- a/frescobaldi_app/scorewiz/parts/strings.py
+++ b/frescobaldi_app/scorewiz/parts/strings.py
@@ -83,7 +83,7 @@ class Contrabass(StringPart):
 
     midiInstrument = 'contrabass'
     clef = 'bass'
-    octave = -1
+    octave = -2
     transposition = (-1, 0, 0)
 
 

--- a/frescobaldi_app/scorewiz/parts/strings.py
+++ b/frescobaldi_app/scorewiz/parts/strings.py
@@ -82,8 +82,9 @@ class Contrabass(StringPart):
         return _("abbreviation for Contrabass", "Cb.")
 
     midiInstrument = 'contrabass'
-    clef = 'bass_8'
-    octave = -2
+    clef = 'bass'
+    octave = -1
+    transposition = (-1, 0, 0)
 
 
 class BassoContinuo(Cello):

--- a/frescobaldi_app/scorewiz/parts/woodwind.py
+++ b/frescobaldi_app/scorewiz/parts/woodwind.py
@@ -52,6 +52,7 @@ class Piccolo(WoodWindPart):
         return _("abbreviation for Piccolo", "Pic.")
 
     midiInstrument = 'piccolo'
+    octave = 2
     transposition = (1, 0, 0)
 
 
@@ -78,6 +79,7 @@ class BassFlute(WoodWindPart):
         return _("abbreviation for Bass flute", "Bfl.")
 
     midiInstrument = 'flute'
+    octave = 0
     transposition = (-1, 0, 0)
 
 
@@ -300,6 +302,7 @@ class SopraninoRecorder(WoodWindPart):
         return _("abbreviation for Sopranino recorder", "Si.rec.")
 
     midiInstrument = 'recorder'
+    octave = 2
     transposition = (1, 0, 0)
 
 class SopranoRecorder(WoodWindPart):
@@ -312,6 +315,7 @@ class SopranoRecorder(WoodWindPart):
         return _("abbreviation for Soprano recorder", "S.rec.")
 
     midiInstrument = 'recorder'
+    octave = 2
     transposition = (1, 0, 0)
 
 
@@ -349,9 +353,9 @@ class BassRecorder(WoodWindPart):
         return _("abbreviation for Bass recorder", "B.rec.")
 
     midiInstrument = 'recorder'
-    transposition = (1, 0, 0)
     clef = 'bass'
-    octave = -1
+    octave = 0
+    transposition = (1, 0, 0)
 
 
 class ContraBassRecorder(WoodWindPart):
@@ -379,7 +383,8 @@ class SubContraBassRecorder(WoodWindPart):
 
     midiInstrument = 'recorder'
     clef = 'bass'
-    octave = -1
+    octave = -2
+    transposition = (-1, 0, 0)
 
 
 


### PR DESCRIPTION
This PR makes various improvements to the Score Wizard.

Most notably, it standardizes the handling of transposing instruments so that **music for all instruments is now entered at concert pitch**. Previously there was separate transposition logic for instruments that transpose at the octave vs. other intervals, with subtly different behavior for each. Now all instruments use the same transposition logic.

As part of this work, I have implemented the change I recommended in issue #1733 moving `\transposition` from the music assignment to the staff definition block. This should have several other benefits as detailed in the issue thread.

In a previous patch I changed double bass to use the `bass_8` clef to match the existing behavior for bass guitar. I have since learned this was incorrect, as octave clefs are not considered standard for either instrument. Part of my motivation for cleaning up the transposition logic was to correct this; both instruments now use the standard bass clef.

While the `treble_8` clef *is* sometimes used for guitar (including for most examples in LilyPond's documentation), my understanding is the standard clef remains more common. I have therefore changed guitar to use it for consistency with other transposing instruments.

Finally, this also fixes a bug I discovered during testing where a MIDI instrument is not assigned to the tab staff when both standard and tab staffs are selected for a part.