### PR TITLE
Add a tag required by Flathub validation

### DIFF
--- a/linux/org.frescobaldi.Frescobaldi.metainfo.xml.in
+++ b/linux/org.frescobaldi.Frescobaldi.metainfo.xml.in
@@ -3,6 +3,7 @@
   <id>org.frescobaldi.Frescobaldi</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
+  <developer_name>Frescobaldi project</developer_name>
   <name>Frescobaldi</name>
   <summary>LilyPond Music Editor</summary>
 


### PR DESCRIPTION
This tag is required to pass Flathub validation and publish new versions on Flathub.

As developer name I chose "Frescobaldi project".
Wilbert is the original author of course, but in this case I think we want to show who is actively developing and maintaining Frescobaldi.
