### PR TITLE
Don't crash when running from a git repo, but git is not on PATH

### DIFF
--- a/frescobaldi_app/vcs/gitrepo.py
+++ b/frescobaldi_app/vcs/gitrepo.py
@@ -65,10 +65,13 @@ class Repo(AbstractVCSRepo):
         git_cmd = git_cmd if git_cmd else "git"
         cmd = [git_cmd, cmd]
         cmd.extend(args)
-        pr = subprocess.Popen(cmd, cwd=dir,
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE,
-                              universal_newlines=True)
+        try:
+            pr = subprocess.Popen(cmd, cwd=dir,
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.PIPE,
+                                  universal_newlines=True)
+        except FileNotFoundError as e:
+            raise GitError(str(e))
         (out, error) = pr.communicate()
         if error:
             raise GitError(error)


### PR DESCRIPTION
How to reproduce the issue:

Clone the Frescobaldi repository. Run from the git-controlled sources while making sure that the git executable is not on PATH, e.g.

```sh
PATH= /usr/bin/python3 ./frescobaldi
```

It crashes miserably on startup.

(Originally reported [here](https://github.com/frescobaldi/frescobaldi/pull/1780#discussion_r1730039265).)