### PR TITLE
Score Wizard improvements, Qt 6 edition

### DIFF
--- a/frescobaldi/scorewiz/build.py
+++ b/frescobaldi/scorewiz/build.py
@@ -23,7 +23,6 @@ Builds the LilyPond score from the settings in the Score Wizard.
 
 
 import collections
-import fractions
 import re
 
 import ly.dom
@@ -127,11 +126,6 @@ class PartData:
         ly.dom.Pitch(octave, 0, 0, stub)
         s = ly.dom.Seq(stub)
         ly.dom.Identifier(self.globalName, s).after = 1
-        if transposition is not None:
-            toct, tnote, talter = transposition
-            # this corrects the sounding pitch for MIDI after
-            # the written pitch is transposed by SingleVoicePart.build()
-            ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2), ly.dom.Transposition(s))
         ly.dom.LineComment(_("Music follows here."), s)
         ly.dom.BlankLine(s)
         return a

--- a/frescobaldi/scorewiz/build.py
+++ b/frescobaldi/scorewiz/build.py
@@ -237,6 +237,9 @@ class Builder:
             ly.dom.BlankLine(block.scores)
             score = ly.dom.Score(block.scores)
             midi = ly.dom.Midi(score)
+            # set MIDI tempo if necessary
+            if not self.showMetronomeMark:
+                self.setMidiTempo(midi)
             if len(self.midiParts) == 1:
                 score.insert(0, self.midiParts[0])
             else:
@@ -280,11 +283,7 @@ class Builder:
                 midi = ly.dom.Midi(score)
                 # set MIDI tempo if necessary
                 if not self.showMetronomeMark:
-                    if self.lyVersion >= (2, 16, 0):
-                        scoreProperties.lySimpleMidiTempo(midi)
-                        midi[0].after = 1
-                    else:
-                        scoreProperties.lyMidiTempo(ly.dom.Context('Score', midi))
+                    self.setMidiTempo(midi)
             music = ly.dom.Simr()
             score.insert(0, music)
 
@@ -339,8 +338,6 @@ class Builder:
             parents = [p for p in partData if not p.isChild]
             makeRecursive(parents, music)
             if self.midi and self.separateMidi:
-                if not self.showMetronomeMark:
-                    self.midiParts.append(scoreProperties.lySimpleMidiTempo(None))
                 self.midiParts.append(music.copy())
 
             # add the prefix to the assignments if necessary
@@ -510,6 +507,14 @@ class Builder:
         """Sets the MIDI instrument for the node, if the user wants MIDI output."""
         if self.midi:
             node.getWith()['midiInstrument'] = midiInstrument
+
+    def setMidiTempo(self, node):
+        """Sets the MIDI tempo when the metronome mark is hidden."""
+        if self.lyVersion >= (2, 16, 0):
+            self.scoreProperties.lySimpleMidiTempo(node)
+            node[0].after = 1
+        else:
+            self.scoreProperties.lyMidiTempo(ly.dom.Context('Score', node))
 
     def setInstrumentNames(self, staff, longName, shortName):
         """Sets the instrument names to the staff (or group).

--- a/frescobaldi/scorewiz/build.py
+++ b/frescobaldi/scorewiz/build.py
@@ -119,7 +119,7 @@ class PartData:
         self.assignments.append(a)
         return a
 
-    def assignMusic(self, name=None, octave=0, transposition=None):
+    def assignMusic(self, name=None, octave=0):
         """Creates a ly.dom.Assignment with a \\relative music stub."""
         a = self.assign(name)
         stub = ly.dom.Relative(a)

--- a/frescobaldi/scorewiz/build.py
+++ b/frescobaldi/scorewiz/build.py
@@ -338,6 +338,11 @@ class Builder:
             parents = [p for p in partData if not p.isChild]
             makeRecursive(parents, music)
             if self.midi and self.separateMidi:
+                # We intentionally duplicate the list of parts rather than
+                # placing it in an assignment because the point of having
+                # separate \score blocks is that they can be edited separately.
+                # For example, a part can be muted by commenting out its line
+                # in the MIDI score while leaving it visible in print.
                 self.midiParts.append(music.copy())
 
             # add the prefix to the assignments if necessary

--- a/frescobaldi/scorewiz/build.py
+++ b/frescobaldi/scorewiz/build.py
@@ -24,6 +24,7 @@ Builds the LilyPond score from the settings in the Score Wizard.
 
 import collections
 import re
+import fractions
 
 import ly.dom
 import i18n
@@ -568,6 +569,19 @@ class Builder:
         # save this to calculate the 'indent' value in document()
         if self.showInstrumentNames:
             self.longestInstrumentNameLength = max(self.longestInstrumentNameLength, len(longName))
+
+    def setStaffTransposition(self, node, transposition):
+        """Sets the transposition of a staff for a transposing instrument."""
+        toct, tnote, talter = transposition
+        # Transpose MIDI output from written c' to the sounding pitch
+        ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2),
+                     ly.dom.Transposition(node))
+        # Transpose both notation and MIDI output from the sounding pitch
+        # to written c' (canceling out the previous \transposition for MIDI)
+        stub = ly.dom.Command('transpose', node)
+        ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2), stub)
+        ly.dom.Pitch(0, 0, 0, stub)
+        return ly.dom.Seqr(stub)
 
 
 def assignparts(group):

--- a/frescobaldi/scorewiz/parts/_base.py
+++ b/frescobaldi/scorewiz/parts/_base.py
@@ -113,7 +113,7 @@ class SingleVoicePart(Part):
     transposition = None # or a three tuple (octave, note, alteration)
 
     def build(self, data, builder):
-        a = data.assignMusic(None, self.octave, self.transposition)
+        a = data.assignMusic(None, self.octave)
         staff = ly.dom.Staff()
         builder.setInstrumentNamesFromPart(staff, self, data)
         if self.midiInstrument:

--- a/frescobaldi/scorewiz/parts/_base.py
+++ b/frescobaldi/scorewiz/parts/_base.py
@@ -79,6 +79,19 @@ class Base:
 class Part(Base):
     """Base class for Parts (that can't contain other parts)."""
 
+    def _writeTransposed(self, seq):
+        """Alter the written pitch of transposing parts."""
+        toct, tnote, talter = self.transposition
+        # \transposition, which only affects MIDI output, sets the sounding
+        # pitch for written c'. We use it to cancel out the change in sounding
+        # pitch from \transpose, which affects both notation and MIDI output.
+        ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2),
+                     ly.dom.Transposition(seq))
+        stub = ly.dom.Command('transpose', seq)
+        ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2), stub)
+        ly.dom.Pitch(0, 0, 0, stub)
+        return ly.dom.Seqr(stub)
+
 
 
 class Container(Base):
@@ -109,16 +122,7 @@ class SingleVoicePart(Part):
         if self.clef:
             ly.dom.Clef(self.clef, seq)
         if self.transposition is not None:
-            toct, tnote, talter = self.transposition
-            if tnote or talter:
-                # use the appropriate key for non-octave transpositions
-                stub = ly.dom.Command('transpose', seq)
-                # the sounding pitch from PartData.assignMusic()...
-                ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2), stub)
-                # ...becomes our written middle C
-                ly.dom.Pitch(0, 0, 0, stub)
-                # place the music within our \transpose block
-                seq = ly.dom.Seqr(stub)
+            seq = self._writeTransposed(seq)
         ly.dom.Identifier(a.name, seq)
         data.nodes.append(staff)
 
@@ -126,6 +130,8 @@ class SingleVoicePart(Part):
 class PianoStaffPart(Part):
     """Base class for parts creating a piano staff."""
     midiInstruments = ()  # may contain a list of MIDI instruments.
+    octave = 1  # for the right hand part; left is 1 octave lower.
+    transposition = None
 
     def createWidgets(self, layout):
         self.label = QLabel(wordWrap=True)
@@ -191,6 +197,8 @@ class PianoStaffPart(Part):
         c = ly.dom.Seqr(staff)
         if clef:
             ly.dom.Clef(clef, c)
+        if self.transposition is not None:
+            c = self._writeTransposed(c)
         if numVoices == 1:
             a = data.assignMusic(name, octave)
             ly.dom.Identifier(a.name, c)
@@ -220,12 +228,12 @@ class PianoStaffPart(Part):
         builder.setInstrumentNamesFromPart(p, self, data)
         s = ly.dom.Sim(p)
         # add two staves, with a respective number of voices.
-        self.buildStaff(data, builder, 'right', 1, self.upperVoices.value(), s)
+        self.buildStaff(data, builder, 'right', self.octave, self.upperVoices.value(), s)
         if (self.dynamicsStaff.isChecked()
             and self.upperVoices.value() and self.lowerVoices.value()):
             # both staffs have to be present to use this feature
             self.buildDynamicsStaff(data, s)
-        self.buildStaff(data, builder, 'left', 0, self.lowerVoices.value(), s, "bass")
+        self.buildStaff(data, builder, 'left', self.octave - 1, self.lowerVoices.value(), s, "bass")
         data.nodes.append(p)
 
 

--- a/frescobaldi/scorewiz/parts/_base.py
+++ b/frescobaldi/scorewiz/parts/_base.py
@@ -79,14 +79,14 @@ class Base:
 class Part(Base):
     """Base class for Parts (that can't contain other parts)."""
 
-    def _writeTransposed(self, seq):
-        """Alter the written pitch of transposing parts."""
+    def _transposeStaff(self, seq):
+        """Add transposition commands to a \\new Staff block."""
         toct, tnote, talter = self.transposition
-        # \transposition, which only affects MIDI output, sets the sounding
-        # pitch for written c'. We use it to cancel out the change in sounding
-        # pitch from \transpose, which affects both notation and MIDI output.
+        # Transpose MIDI output from written c' to the sounding pitch
         ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2),
                      ly.dom.Transposition(seq))
+        # Transpose both notation and MIDI output from the sounding pitch
+        # to written c' (canceling out the previous \transposition for MIDI)
         stub = ly.dom.Command('transpose', seq)
         ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2), stub)
         ly.dom.Pitch(0, 0, 0, stub)
@@ -122,7 +122,7 @@ class SingleVoicePart(Part):
         if self.clef:
             ly.dom.Clef(self.clef, seq)
         if self.transposition is not None:
-            seq = self._writeTransposed(seq)
+            seq = self._transposeStaff(seq)
         ly.dom.Identifier(a.name, seq)
         data.nodes.append(staff)
 
@@ -198,7 +198,7 @@ class PianoStaffPart(Part):
         if clef:
             ly.dom.Clef(clef, c)
         if self.transposition is not None:
-            c = self._writeTransposed(c)
+            c = self._transposeStaff(c)
         if numVoices == 1:
             a = data.assignMusic(name, octave)
             ly.dom.Identifier(a.name, c)

--- a/frescobaldi/scorewiz/parts/brass.py
+++ b/frescobaldi/scorewiz/parts/brass.py
@@ -118,6 +118,57 @@ class Trombone(BrassPart):
     octave = -1
 
 
+class TromboneBb(Trombone):
+    @staticmethod
+    def title(_=_base.translate):
+        return _("Trombone in Bb")
+
+    @staticmethod
+    def short(_=_base.translate):
+        return _("abbreviation for Trombone in Bb", "Trb.Bb.")
+
+    # British brass band notation
+    clef = None
+    transposition = (-2, 6, -1)
+
+
+class AltoTrombone(Trombone):
+    @staticmethod
+    def title(_=_base.translate):
+        return _("Alto trombone")
+
+    @staticmethod
+    def short(_=_base.translate):
+        return _("abbreviation for Alto trombone", "A.Trb.")
+
+    clef = 'alto'
+    octave = 0
+
+
+class BassTrombone(Trombone):
+    @staticmethod
+    def title(_=_base.translate):
+        return _("Bass trombone")
+
+    @staticmethod
+    def short(_=_base.translate):
+        return _("abbreviation for Bass trombone", "B.Trb.")
+
+
+class TenorHorn(BrassPart):
+    @staticmethod
+    def title(_=_base.translate):
+        return _("Tenor horn")
+
+    @staticmethod
+    def short(_=_base.translate):
+        return _("abbreviation for Tenor horn", "T.Hn.")
+
+    midiInstrument = 'french horn'
+    octave = -1
+    transposition = (-1, 2, -1)
+
+
 class Baritone(BrassPart):
     @staticmethod
     def title(_=_base.translate):
@@ -156,7 +207,35 @@ class Tuba(BrassPart):
         return _("abbreviation for Tuba", "Tb.")
 
     midiInstrument = 'tuba'
+    clef = 'bass'
     octave = -1
+
+
+class TubaEb(Tuba):
+    @staticmethod
+    def title(_=_base.translate):
+        return _("Tuba in Eb")
+
+    @staticmethod
+    def short(_=_base.translate):
+        return _("abbreviation for Tuba in Eb", "Tb.Eb.")
+
+    # British brass band notation
+    clef = None
+    transposition = (-1, 2, -1)
+
+
+class TubaBb(Tuba):
+    @staticmethod
+    def title(_=_base.translate):
+        return _("Tuba in Bb")
+
+    @staticmethod
+    def short(_=_base.translate):
+        return _("abbreviation for Tuba in Bb", "Tb.Bb.")
+
+    # British brass band notation
+    clef = None
     transposition = (-2, 6, -1)
 
 
@@ -185,8 +264,14 @@ register(
         Flugelhorn,
         Mellophone,
         Trombone,
+        TromboneBb,
+        AltoTrombone,
+        BassTrombone,
+        TenorHorn,
         Baritone,
         Euphonium,
         Tuba,
+        TubaEb,
+        TubaBb,
         BassTuba,
     ])

--- a/frescobaldi/scorewiz/parts/brass.py
+++ b/frescobaldi/scorewiz/parts/brass.py
@@ -242,11 +242,11 @@ class TubaBb(Tuba):
 class BassTuba(BrassPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("Bass Tuba")
+        return _("Bass tuba")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Bass Tuba", "B.Tb.")
+        return _("abbreviation for Bass tuba", "B.Tb.")
 
     midiInstrument = 'tuba'
     clef = 'bass'

--- a/frescobaldi/scorewiz/parts/brass.py
+++ b/frescobaldi/scorewiz/parts/brass.py
@@ -40,6 +40,7 @@ class HornF(BrassPart):
         return _("abbreviation for Horn in F", "Hn.F.")
 
     midiInstrument = 'french horn'
+    octave = 0
     transposition = (-1, 3, 0)
 
 
@@ -99,6 +100,7 @@ class Mellophone(BrassPart):
         return _("abbreviation for Mellophone", "Mph.")
 
     midiInstrument = 'french horn'
+    octave = 0
     transposition = (-1, 3, 0)
 
 
@@ -154,6 +156,7 @@ class Tuba(BrassPart):
         return _("abbreviation for Tuba", "Tb.")
 
     midiInstrument = 'tuba'
+    octave = -1
     transposition = (-2, 6, -1)
 
 
@@ -168,8 +171,8 @@ class BassTuba(BrassPart):
 
     midiInstrument = 'tuba'
     clef = 'bass'
-    octave = -1
-    transposition = (-2, 0, 0)
+    octave = -2
+    transposition = (-1, 0, 0)
 
 
 register(

--- a/frescobaldi/scorewiz/parts/containers.py
+++ b/frescobaldi/scorewiz/parts/containers.py
@@ -56,6 +56,7 @@ class StaffGroup(_base.Container):
             (lambda: _("Square"), 'system_start_square'),
             ), self.systemStart, display=listmodel.translate_index(0),
             icon=lambda item: symbols.icon(item[1])))
+        self.systemStart.setCurrentIndex(1) # bracket
         self.systemStart.setIconSize(QSize(64, 64))
         self.connectBarLines = QCheckBox(checked=True)
 

--- a/frescobaldi/scorewiz/parts/containers.py
+++ b/frescobaldi/scorewiz/parts/containers.py
@@ -38,7 +38,7 @@ from . import register
 class StaffGroup(_base.Container):
     @staticmethod
     def title(_=_base.translate):
-        return _("Staff Group")
+        return _("Staff group")
 
     def accepts(self):
         return (StaffGroup, _base.Part)
@@ -67,7 +67,7 @@ class StaffGroup(_base.Container):
 
     def translateWidgets(self):
         self.systemStartLabel.setText(_("Type:"))
-        self.connectBarLines.setText(_("Connect Barlines"))
+        self.connectBarLines.setText(_("Connect barlines"))
         self.connectBarLines.setToolTip(_("If checked, barlines are connected between the staves."))
         self.systemStart.model().update()
 
@@ -147,7 +147,7 @@ class Score(_base.Group, scoreproperties.ScoreProperties):
 class BookPart(_base.Group):
     @staticmethod
     def title(_=_base.translate):
-        return _("Book Part")
+        return _("Book part")
 
     def accepts(self):
         return (Score, StaffGroup, _base.Part)
@@ -187,7 +187,7 @@ class Book(_base.Group):
             "<p>If you choose \"Suffix\" the entered name will be appended "
             "to the document's file name; if you choose \"Filename\", just "
             "the entered name will be used.</p>"))
-        self.bookOutputLabel.setText(_("Output Filename:"))
+        self.bookOutputLabel.setText(_("Output filename:"))
         self.bookOutputFileName.setText(_("Filename"))
         self.bookOutputSuffix.setText(_("Suffix"))
 

--- a/frescobaldi/scorewiz/parts/keyboard.py
+++ b/frescobaldi/scorewiz/parts/keyboard.py
@@ -144,6 +144,8 @@ class Celesta(KeyboardPart):
         return _("abbreviation for Celesta", "Cel.")
 
     midiInstrument = 'celesta'
+    octave = 2
+    transposition = (1, 0, 0)
 
 
 class SynthPart(KeyboardPart):

--- a/frescobaldi/scorewiz/parts/percussion.py
+++ b/frescobaldi/scorewiz/parts/percussion.py
@@ -61,6 +61,8 @@ class Xylophone(PitchedPercussionPart):
         return _("abbreviation for Xylophone", "Xyl.")
 
     midiInstrument = 'xylophone'
+    octave = 2
+    transposition = (1, 0, 0)
 
 
 class Marimba(_base.PianoStaffPart):
@@ -151,6 +153,8 @@ class Glockenspiel(PitchedPercussionPart):
         return _("abbreviation for Glockenspiel", "Gls.")
 
     midiInstrument = 'glockenspiel'
+    octave = 3
+    transposition = (2, 0, 0)
 
 
 class Carillon(_base.PianoStaffPart):

--- a/frescobaldi/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi/scorewiz/parts/plucked_strings.py
@@ -342,13 +342,25 @@ class Guitar(TablaturePart):
         box.addWidget(self.voicesLabel)
         box.addWidget(self.voices)
         layout.addLayout(box)
+        self.octaveClef = QCheckBox()
+        layout.addWidget(self.octaveClef)
 
     def translateWidgets(self):
         super().translateWidgets()
         self.voicesLabel.setText(_("Voices:"))
+        self.octaveClef.setText(_("Include octave indication"))
+        self.octaveClef.setToolTip(_(
+            "Use an octave (treble_8) clef to make transposition explicit "
+            "as preferred by some style guides."))
 
     def voiceCount(self):
         return self.voices.value()
+
+    def build(self, data, builder):
+        if self.octaveClef.isChecked():
+            self.clef = "treble_8"
+            self.transposition = None
+        super().build(data, builder)
 
 
 class AcousticGuitar(Guitar):

--- a/frescobaldi/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi/scorewiz/parts/plucked_strings.py
@@ -184,6 +184,11 @@ class TablaturePart(_base.Part):
             if self.tabFormat:
                 tabstaff.getWith()['tablatureFormat'] = ly.dom.Scheme(self.tabFormat)
             self.setTunings(tabstaff)
+            if self.midiInstruments:
+                builder.setMidiInstrument(tabstaff,
+                    self.midiInstrumentSelection.currentText())
+            else:
+                builder.setMidiInstrument(tabstaff, self.midiInstrument)
             sim = ly.dom.Simr(tabstaff)
             if numVoices == 1:
                 ly.dom.Identifier(assignments[0].name, sim)
@@ -198,7 +203,6 @@ class TablaturePart(_base.Part):
             p = staff
         elif staffType == 1:
             # only a TabStaff
-            builder.setMidiInstrument(tabstaff, self.midiInstrument)
             p = tabstaff
         else:
             # both TabStaff and normal staff

--- a/frescobaldi/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi/scorewiz/parts/plucked_strings.py
@@ -165,6 +165,8 @@ class TablaturePart(_base.Part):
             seq = ly.dom.Seqr(staff)
             if self.clef:
                 ly.dom.Clef(self.clef, seq)
+            if self.transposition is not None:
+                seq = self._writeTransposed(seq)
             mus = ly.dom.Simr(seq)
             for a in assignments[:-1]:
                 ly.dom.Identifier(a.name, mus)

--- a/frescobaldi/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi/scorewiz/parts/plucked_strings.py
@@ -322,7 +322,7 @@ class Guitar(TablaturePart):
         return _("abbreviation for Guitar", "Gt.")
 
     midiInstrument = 'acoustic guitar (nylon)'
-    transposition = (-1, 0, 0)
+    transposition = (-1, 0, 0)  # but see build() below
     tunings = (
         ('guitar-tuning', lambda: _("Guitar tuning")),
         ('guitar-seven-string-tuning', lambda: _("Guitar seven-string tuning")),
@@ -360,6 +360,9 @@ class Guitar(TablaturePart):
         if self.octaveClef.isChecked():
             self.clef = "treble_8"
             self.transposition = None
+        else:
+            self.clef = None
+            self.transposition = (-1, 0, 0)
         super().build(data, builder)
 
 

--- a/frescobaldi/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi/scorewiz/parts/plucked_strings.py
@@ -165,7 +165,7 @@ class TablaturePart(_base.Part):
             if self.clef:
                 ly.dom.Clef(self.clef, seq)
             if self.transposition is not None:
-                seq = self._transposeStaff(seq)
+                seq = builder.setStaffTransposition(seq, self.transposition)
             mus = ly.dom.Simr(seq)
             for a in assignments[:-1]:
                 ly.dom.Identifier(a.name, mus)

--- a/frescobaldi/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi/scorewiz/parts/plucked_strings.py
@@ -155,8 +155,7 @@ class TablaturePart(_base.Part):
             order = 1, 2, 3, 4
             voices = [ly.util.mkid(data.name(), "voice") + ly.util.int2text(i) for i in order]
 
-        assignments = [data.assignMusic(name, self.octave, self.transposition)
-                       for name in voices]
+        assignments = [data.assignMusic(name, self.octave) for name in voices]
 
         staffType = self.staffType.currentIndex()
         if staffType in (0, 2):

--- a/frescobaldi/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi/scorewiz/parts/plucked_strings.py
@@ -318,7 +318,7 @@ class Guitar(TablaturePart):
         return _("abbreviation for Guitar", "Gt.")
 
     midiInstrument = 'acoustic guitar (nylon)'
-    clef = "treble_8"
+    transposition = (-1, 0, 0)
     tunings = (
         ('guitar-tuning', lambda: _("Guitar tuning")),
         ('guitar-seven-string-tuning', lambda: _("Guitar seven-string tuning")),
@@ -392,8 +392,9 @@ class AcousticBass(TablaturePart):
         return _("abbreviation for Acoustic bass", "A.Bs.") #FIXME
 
     midiInstrument = 'acoustic bass'
-    clef = 'bass_8'
+    clef = 'bass'
     octave = -2
+    transposition = (-1, 0, 0)
     tunings = (
         ('bass-tuning', lambda: _("Bass tuning")),
         ('bass-four-string-tuning', lambda: _("Four-string bass tuning")),

--- a/frescobaldi/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi/scorewiz/parts/plucked_strings.py
@@ -275,6 +275,7 @@ class Banjo(TablaturePart):
         return _("abbreviation for Banjo", "Bj.")
 
     midiInstrument = 'banjo'
+    transposition = (-1, 0, 0)
     tabFormat = 'fret-number-tablature-format-banjo'
     tunings = (
         ('banjo-open-g-tuning', lambda: _("Open G-tuning (aDGBD)")),

--- a/frescobaldi/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi/scorewiz/parts/plucked_strings.py
@@ -166,7 +166,7 @@ class TablaturePart(_base.Part):
             if self.clef:
                 ly.dom.Clef(self.clef, seq)
             if self.transposition is not None:
-                seq = self._writeTransposed(seq)
+                seq = self._transposeStaff(seq)
             mus = ly.dom.Simr(seq)
             for a in assignments[:-1]:
                 ly.dom.Identifier(a.name, mus)

--- a/frescobaldi/scorewiz/parts/special.py
+++ b/frescobaldi/scorewiz/parts/special.py
@@ -62,7 +62,7 @@ class Chords(_base.ChordNames, _base.Part):
 class BassFigures(_base.Part):
     @staticmethod
     def title(_=_base.translate):
-        return _("Figured Bass")
+        return _("Figured bass")
 
     def createWidgets(self, layout):
         self.extenderLines = QCheckBox()

--- a/frescobaldi/scorewiz/parts/strings.py
+++ b/frescobaldi/scorewiz/parts/strings.py
@@ -90,11 +90,11 @@ class Contrabass(StringPart):
 class BassoContinuo(Cello):
     @staticmethod
     def title(_=_base.translate):
-        return _("Basso Continuo")
+        return _("Basso continuo")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Basso Continuo", "B.c.")
+        return _("abbreviation for Basso continuo", "B.C.")
 
     def build(self, data, builder):
         super().build(data, builder)

--- a/frescobaldi/scorewiz/parts/strings.py
+++ b/frescobaldi/scorewiz/parts/strings.py
@@ -82,8 +82,9 @@ class Contrabass(StringPart):
         return _("abbreviation for Contrabass", "Cb.")
 
     midiInstrument = 'contrabass'
-    clef = 'bass_8'
+    clef = 'bass'
     octave = -2
+    transposition = (-1, 0, 0)
 
 
 class BassoContinuo(Cello):

--- a/frescobaldi/scorewiz/parts/woodwind.py
+++ b/frescobaldi/scorewiz/parts/woodwind.py
@@ -59,11 +59,11 @@ class Piccolo(WoodWindPart):
 class AltoFlute(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("Alto Flute")
+        return _("Alto flute")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation Alto flute", "Afl.")
+        return _("abbreviation for Alto flute", "A.Fl.")
 
     midiInstrument = 'flute'
     octave = 0
@@ -169,11 +169,11 @@ class Clarinet(WoodWindPart):
 class EflatClarinet(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("E-flat clarinet ")
+        return _("E-flat clarinet")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for E-flat Clarinet", "Cl. in Eb")
+        return _("abbreviation for E-flat clarinet", "Cl. in Eb")
 
     midiInstrument = 'clarinet'
     transposition = (0, 2, -1)
@@ -182,11 +182,11 @@ class EflatClarinet(WoodWindPart):
 class AClarinet(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("A clarinet ")
+        return _("A clarinet")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for A Clarinet", "Cl. in A")
+        return _("abbreviation for A clarinet", "Cl. in A")
 
     midiInstrument = 'clarinet'
     octave = 0
@@ -200,7 +200,7 @@ class BassClarinet(WoodWindPart):
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Bass clarinet", "BCl.")
+        return _("abbreviation for Bass clarinet", "B.Cl.")
 
     midiInstrument = 'clarinet'
     octave = -1
@@ -210,11 +210,11 @@ class BassClarinet(WoodWindPart):
 class C_MelodySax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("C-Melody Sax")
+        return _("C-melody saxophone")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for C-Melody Sax", "C-Mel Sax")
+        return _("abbreviation for C-melody saxophone", "C-Mel Sax")
 
     midiInstrument = 'soprano sax'
 
@@ -222,11 +222,11 @@ class C_MelodySax(WoodWindPart):
 class SopraninoSax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("Sopranino Sax")
+        return _("Sopranino saxophone")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Sopranino Sax", "SiSx.")
+        return _("abbreviation for Sopranino saxophone", "Si.Sax.")
 
     midiInstrument = 'soprano sax'
     transposition = (0, 2, -1)    # es'
@@ -235,11 +235,11 @@ class SopraninoSax(WoodWindPart):
 class SopranoSax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("Soprano Sax")
+        return _("Soprano saxophone")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Soprano Sax", "SoSx.")
+        return _("abbreviation for Soprano saxophone", "So.Sax.")
 
     midiInstrument = 'soprano sax'
     transposition = (-1, 6, -1)   # bes
@@ -248,11 +248,11 @@ class SopranoSax(WoodWindPart):
 class AltoSax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("Alto Sax")
+        return _("Alto saxophone")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Alto Sax", "ASx.")
+        return _("abbreviation for Alto saxophone", "A.Sax.")
 
     midiInstrument = 'alto sax'
     octave = 0
@@ -262,11 +262,11 @@ class AltoSax(WoodWindPart):
 class TenorSax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("Tenor Sax")
+        return _("Tenor saxophone")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Tenor Sax", "TSx.")
+        return _("abbreviation for Tenor saxophone", "T.Sax.")
 
     midiInstrument = 'tenor sax'
     octave = 0
@@ -276,11 +276,11 @@ class TenorSax(WoodWindPart):
 class BaritoneSax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("Baritone Sax")
+        return _("Baritone saxophone")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Baritone Sax", "BSx.")
+        return _("abbreviation for Baritone saxophone", "B.Sax.")
 
     midiInstrument = 'baritone sax'
     octave = -1
@@ -290,11 +290,11 @@ class BaritoneSax(WoodWindPart):
 class BassSax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("Bass Sax")
+        return _("Bass saxophone")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Bass Sax", "BsSx.")
+        return _("abbreviation for Bass saxophone", "Bs.Sax.")
 
     midiInstrument = 'baritone sax'
     octave = -1
@@ -308,7 +308,7 @@ class SopraninoRecorder(WoodWindPart):
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Sopranino recorder", "Si.rec.")
+        return _("abbreviation for Sopranino recorder", "Si.Rec.")
 
     midiInstrument = 'recorder'
     octave = 2
@@ -321,7 +321,7 @@ class SopranoRecorder(WoodWindPart):
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Soprano recorder", "S.rec.")
+        return _("abbreviation for Soprano recorder", "S.Rec.")
 
     midiInstrument = 'recorder'
     octave = 2
@@ -335,7 +335,7 @@ class AltoRecorder(WoodWindPart):
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Alto recorder", "A.rec.")
+        return _("abbreviation for Alto recorder", "A.Rec.")
 
     midiInstrument = 'recorder'
 
@@ -347,7 +347,7 @@ class TenorRecorder(WoodWindPart):
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Tenor recorder", "T.rec.")
+        return _("abbreviation for Tenor recorder", "T.Rec.")
 
     midiInstrument = 'recorder'
 
@@ -359,7 +359,7 @@ class BassRecorder(WoodWindPart):
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Bass recorder", "B.rec.")
+        return _("abbreviation for Bass recorder", "B.Rec.")
 
     midiInstrument = 'recorder'
     clef = 'bass'
@@ -370,11 +370,11 @@ class BassRecorder(WoodWindPart):
 class ContraBassRecorder(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("Contra Bass recorder")
+        return _("Contrabass recorder")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Contra Bass recorder", "Cb.rec.")
+        return _("abbreviation for Contrabass recorder", "Cb.Rec.")
 
     midiInstrument = 'recorder'
     clef = 'bass'
@@ -384,11 +384,11 @@ class ContraBassRecorder(WoodWindPart):
 class SubContraBassRecorder(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("Subcontra Bass recorder")
+        return _("Subcontrabass recorder")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Subcontra Bass recorder", "Scb.rec.")
+        return _("abbreviation for Subcontrabass recorder", "Scb.Rec.")
 
     midiInstrument = 'recorder'
     clef = 'bass'

--- a/frescobaldi/scorewiz/parts/woodwind.py
+++ b/frescobaldi/scorewiz/parts/woodwind.py
@@ -52,6 +52,7 @@ class Piccolo(WoodWindPart):
         return _("abbreviation for Piccolo", "Pic.")
 
     midiInstrument = 'piccolo'
+    octave = 2
     transposition = (1, 0, 0)
 
 
@@ -65,6 +66,7 @@ class AltoFlute(WoodWindPart):
         return _("abbreviation Alto flute", "Afl.")
 
     midiInstrument = 'flute'
+    octave = 0
     transposition = (-1, 4, 0)
 
 
@@ -78,6 +80,7 @@ class BassFlute(WoodWindPart):
         return _("abbreviation for Bass flute", "Bfl.")
 
     midiInstrument = 'flute'
+    octave = 0
     transposition = (-1, 0, 0)
 
 
@@ -103,6 +106,7 @@ class OboeDAmore(WoodWindPart):
         return _("abbreviation for Oboe d'amore", "Ob.d'am.")
 
     midiInstrument = 'oboe'
+    octave = 0
     transposition = (-1, 5, 0)
 
 
@@ -116,6 +120,7 @@ class EnglishHorn(WoodWindPart):
         return _("abbreviation for English horn", "Eng.h.")
 
     midiInstrument = 'english horn'
+    octave = 0
     transposition = (-1, 3, 0)
 
 
@@ -145,7 +150,7 @@ class ContraBassoon(WoodWindPart):
     midiInstrument = 'bassoon'
     transposition = (-1, 0, 0)
     clef = 'bass'
-    octave = -1
+    octave = -2
 
 
 class Clarinet(WoodWindPart):
@@ -184,6 +189,7 @@ class AClarinet(WoodWindPart):
         return _("abbreviation for A Clarinet", "Cl. in A")
 
     midiInstrument = 'clarinet'
+    octave = 0
     transposition = (-1, 5, 0)
 
 
@@ -197,6 +203,7 @@ class BassClarinet(WoodWindPart):
         return _("abbreviation for Bass clarinet", "BCl.")
 
     midiInstrument = 'clarinet'
+    octave = -1
     transposition = (-2, 6, -1)
 
 
@@ -248,6 +255,7 @@ class AltoSax(WoodWindPart):
         return _("abbreviation for Alto Sax", "ASx.")
 
     midiInstrument = 'alto sax'
+    octave = 0
     transposition = (-1, 2, -1)   # es
 
 
@@ -261,6 +269,7 @@ class TenorSax(WoodWindPart):
         return _("abbreviation for Tenor Sax", "TSx.")
 
     midiInstrument = 'tenor sax'
+    octave = 0
     transposition = (-2, 6, -1)   # bes,
 
 
@@ -274,6 +283,7 @@ class BaritoneSax(WoodWindPart):
         return _("abbreviation for Baritone Sax", "BSx.")
 
     midiInstrument = 'baritone sax'
+    octave = -1
     transposition = (-2, 2, -1)   # es,
 
 
@@ -287,6 +297,7 @@ class BassSax(WoodWindPart):
         return _("abbreviation for Bass Sax", "BsSx.")
 
     midiInstrument = 'baritone sax'
+    octave = -1
     transposition = (-3, 6, -1)   # bes,,
 
 
@@ -300,6 +311,7 @@ class SopraninoRecorder(WoodWindPart):
         return _("abbreviation for Sopranino recorder", "Si.rec.")
 
     midiInstrument = 'recorder'
+    octave = 2
     transposition = (1, 0, 0)
 
 class SopranoRecorder(WoodWindPart):
@@ -312,6 +324,7 @@ class SopranoRecorder(WoodWindPart):
         return _("abbreviation for Soprano recorder", "S.rec.")
 
     midiInstrument = 'recorder'
+    octave = 2
     transposition = (1, 0, 0)
 
 
@@ -349,9 +362,9 @@ class BassRecorder(WoodWindPart):
         return _("abbreviation for Bass recorder", "B.rec.")
 
     midiInstrument = 'recorder'
-    transposition = (1, 0, 0)
     clef = 'bass'
-    octave = -1
+    octave = 0
+    transposition = (1, 0, 0)
 
 
 class ContraBassRecorder(WoodWindPart):
@@ -379,7 +392,8 @@ class SubContraBassRecorder(WoodWindPart):
 
     midiInstrument = 'recorder'
     clef = 'bass'
-    octave = -1
+    octave = -2
+    transposition = (-1, 0, 0)
 
 
 

--- a/frescobaldi/scorewiz/parts/woodwind.py
+++ b/frescobaldi/scorewiz/parts/woodwind.py
@@ -77,7 +77,7 @@ class BassFlute(WoodWindPart):
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Bass flute", "Bfl.")
+        return _("abbreviation for Bass flute", "B.Fl.")
 
     midiInstrument = 'flute'
     octave = 0
@@ -103,7 +103,7 @@ class OboeDAmore(WoodWindPart):
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Oboe d'amore", "Ob.d'am.")
+        return _("abbreviation for Oboe d'amore", "Ob.D'am.")
 
     midiInstrument = 'oboe'
     octave = 0
@@ -117,7 +117,7 @@ class EnglishHorn(WoodWindPart):
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for English horn", "Eng.h.")
+        return _("abbreviation for English horn", "Eng.H.")
 
     midiInstrument = 'english horn'
     octave = 0


### PR DESCRIPTION
This PR includes several Score Wizard improvements that I'd postponed to focus on finishing the Qt 6 port. Most notably, it reworks the handling of transposing instruments as discussed under #1733 and #1800.

It also adds a couple new instrument types, fixes a few bugs, and standardizes spelling and punctuation of instrument names.