### PR TITLE
Fix string that is passed to setDesktopFilename

### DIFF
--- a/frescobaldi_app/appinfo.py
+++ b/frescobaldi_app/appinfo.py
@@ -40,7 +40,7 @@ license = "GPL"
 # this one is used everywhere in the application
 appname = "Frescobaldi"
 
-desktop_file_name = "org.frescobaldi.Frescobaldi.desktop"
+desktop_file_name = "org.frescobaldi.Frescobaldi"
 
 # required versions of important dependencies
 required_python_version = (3, 8)


### PR DESCRIPTION
Currently, a warning is generated. According to the docs (and this warning), the
`QGuiApplication::desktopFileName` should be called without the `.desktop`
extension.

https://doc.qt.io/qt-6/qguiapplication.html#desktopFileName-prop
