### PR TITLE
Qt6 credit fixes

### DIFF
--- a/frescobaldi_app/debuginfo.py
+++ b/frescobaldi_app/debuginfo.py
@@ -130,8 +130,9 @@ def version_info_named():
     yield "Qt", qt_version()
     yield "PyQt", pyqt_version()
     yield "qpageview", qpageview_version()
-    yield "poppler", poppler_version()
-    yield "python-poppler-qt", python_poppler_version()
+    ## not used since the switch to PyQt6
+    #yield "poppler", poppler_version()
+    #yield "python-poppler-qt", python_poppler_version()
     yield "OS", operating_system()
     if platform.system() == 'Darwin':
         yield "installation kind", mac_installation_kind()

--- a/frescobaldi_app/userguide/credits.md
+++ b/frescobaldi_app/userguide/credits.md
@@ -2,8 +2,6 @@
 
 {appname} is written in {python} and uses the {qt} toolkit.
 
-The Music View is powered by the {poppler} library by {authors} and others.
-
 Most of the bundled icons are created by {tango}.
 
 The following people contributed to {appname} (in alphabetical order):

--- a/frescobaldi_app/userguide/credits.md
+++ b/frescobaldi_app/userguide/credits.md
@@ -14,27 +14,27 @@ The following people contributed to {appname} (in alphabetical order):
 !Wilbert Berendsen:
 : Main author and core developer
 
+!Peter Bjuhr:
+: !_(Quick Insert buttons for grace notes)_,
+   _(MusicXML, MIDI and ABC im- and export)_,
+   _(Manuscript Viewer)_
+
 !@mr-bronson:
 : Encoding-related fixes and other improvements
 
 !Christopher Bryan:
 : !_(Modal Transpose)_
 
-!Peter Bjuhr:
-: !_(Quick Insert buttons for grace notes)_,
-   _(MusicXML, MIDI and ABC im- and export)_,
-   _(Manuscript Viewer)_
-
 !Richard Cognot:
 : Kinetic Scrolling for the Music View
+
+!Jörg Hoffmann:
+: Windows installers
 
 !Benjamin Johnson:
 : !_(Qt 6 port)_,
    _(Score Wizard improvements)_,
    _(Score Wizard From Current Document)_
-
-!Jörg Hoffmann:
-: Windows installers
 
 !Marnen Laibow-Koser:
 : Homebrew formula for macOS


### PR DESCRIPTION
Two trivial fixes to re-alphabetize names and remove references to Poppler in the About box/credits.