### PR TITLE
Always use PNG for copy to image (#1811)

### DIFF
--- a/frescobaldi_app/copy2image.py
+++ b/frescobaldi_app/copy2image.py
@@ -179,7 +179,8 @@ class Dialog(QDialog):
     def readSettings(self):
         s = QSettings()
         s.beginGroup('copy_image')
-        self.dpiCombo.setEditText(s.value("dpi", "100", str))
+        # 300 dpi is standard print resolution
+        self.dpiCombo.setEditText(s.value("dpi", "300", str))
         color = s.value("papercolor", QColor(), QColor)
         self.colorButton.setColor(color if color.isValid() else Qt.GlobalColor.white)
         self.colorCheck.setChecked(color.isValid())
@@ -232,7 +233,7 @@ class Dialog(QDialog):
 
         # update the preferences of the exporter
         if e.supportsResolution:
-            e.resolution = float(self.dpiCombo.currentText() or '100')
+            e.resolution = float(self.dpiCombo.currentText() or '300')
         if e.supportsPaperColor and self.colorCheck.isChecked():
             e.paperColor = self.colorButton.color()
         if e.supportsGrayscale:

--- a/frescobaldi_app/copy2image.py
+++ b/frescobaldi_app/copy2image.py
@@ -285,9 +285,10 @@ class Dialog(QDialog):
         self.dragfile.setDown(False)
 
     def saveAs(self):
+        typeFilter = _("PNG Image (*.png)")
         filename = self._exporter.suggestedFilename()
         filename = QFileDialog.getSaveFileName(self,
-            _("Save Image As"), filename)[0]
+            _("Save Image As"), filename, filter=typeFilter)[0]
         if filename:
             try:
                 self._exporter.save(filename)

--- a/frescobaldi_app/copy2image.py
+++ b/frescobaldi_app/copy2image.py
@@ -170,11 +170,10 @@ class Dialog(QDialog):
         Called from translateUI() and from updateExport().
 
         """
-        filetype = _("PNG")
-        self.dragdata.setToolTip(_("Drag the {png} image data.").format(png=filetype))
-        self.dragfile.setToolTip(_("Drag the image as a {png} file.").format(png=filetype))
-        self.copydata.setToolTip(_("Copy the {png} image data to Clipboard.").format(png=filetype))
-        self.copyfile.setToolTip(_("Copy the {png} file to Clipboard.").format(png=filetype))
+        self.dragdata.setToolTip(_("Drag the image to embed in a document."))
+        self.dragfile.setToolTip(_("Drag the image as a PNG file."))
+        self.copydata.setToolTip(_("Copy the image to the clipboard."))
+        self.copyfile.setToolTip(_("Copy the image to the clipboard as a PNG file."))
 
     def readSettings(self):
         s = QSettings()


### PR DESCRIPTION
This PR changes the copy to image dialog to always use PNG as discussed under #1811.

I also increased the default copy resolution to 300 dpi because it better fits the use case of copying a selection to a document intended for print, like in Word or LibreOffice Writer for example.

(And sorry, I just realized the first two commits overlap with #1814. Still getting the hang of juggling multiple Git branches.)