### PR TITLE
Prefer remote docs for the user's default LilyPond version

### DIFF
--- a/frescobaldi_app/appinfo.py
+++ b/frescobaldi_app/appinfo.py
@@ -47,5 +47,6 @@ required_python_version = (3, 8)
 required_python_ly_version = (0, 9, 4)
 
 # LilyPond doc URLs to be used in lilydoc/manager.py
+# see also lilypondinfo.LilyPondInfo.lilydoc_url()
 lilydoc_stable = "http://lilypond.org/doc/v2.24"
 lilydoc_development = "http://lilypond.org/doc/v2.25"

--- a/frescobaldi_app/lilydoc/manager.py
+++ b/frescobaldi_app/lilydoc/manager.py
@@ -31,6 +31,7 @@ import appinfo
 import util
 import signals
 import qsettings
+import lilypondinfo
 
 from . import documentation
 
@@ -132,6 +133,13 @@ def urls():
     for p in user_paths:
         user_prefixes.append(p) if os.path.isdir(p) else remote.append(p)
     remote.sort(key=util.naturalsort)
+
+    # prefer remote docs for the user's default LilyPond version
+    installed = lilypondinfo.preferred()
+    if installed.version():
+        remote_url = installed.lilydoc_url()
+        if not remote_url in remote:
+            remote.insert(0, remote_url)
 
     # now find all instances of LilyPond documentation in the local paths
     def paths(path):

--- a/frescobaldi_app/lilypondinfo.py
+++ b/frescobaldi_app/lilypondinfo.py
@@ -393,6 +393,17 @@ class LilyPondInfo:
                 version = self.versionString(),
                 command = self.displaycommand())
 
+    @CachedProperty.cachedproperty(depends=version)
+    def lilydoc_url(self):
+        """Return the URL of this LilyPond version's online documentation."""
+        # see also appinfo.lilydoc_stable and appinfo.lilydoc_development
+        version = self.version()
+        if len(version) >= 2:
+            return "http://lilypond.org/doc/v{major}.{minor}".format(
+                major=version[0], minor=version[1])
+        else:
+            return "http://lilypond.org/doc"
+
     def ly_tool(self, name):
         """Get the configured command for the ly tool (e.g. midi2ly).
 


### PR DESCRIPTION
This helps when users are running an older version of LilyPond that doesn't include local documentation.