### PR TITLE
Add an option to enter music at either written or sounding pitch

### DIFF
--- a/frescobaldi_app/scorewiz/build.py
+++ b/frescobaldi_app/scorewiz/build.py
@@ -23,7 +23,6 @@ Builds the LilyPond score from the settings in the Score Wizard.
 
 
 import collections
-import fractions
 import re
 
 import ly.dom
@@ -127,11 +126,6 @@ class PartData:
         ly.dom.Pitch(octave, 0, 0, stub)
         s = ly.dom.Seq(stub)
         ly.dom.Identifier(self.globalName, s).after = 1
-        if transposition is not None:
-            toct, tnote, talter = transposition
-            # this corrects the sounding pitch for MIDI after
-            # the written pitch is transposed by SingleVoicePart.build()
-            ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2), ly.dom.Transposition(s))
         ly.dom.LineComment(_("Music follows here."), s)
         ly.dom.BlankLine(s)
         return a

--- a/frescobaldi_app/scorewiz/parts/_base.py
+++ b/frescobaldi_app/scorewiz/parts/_base.py
@@ -79,6 +79,19 @@ class Base:
 class Part(Base):
     """Base class for Parts (that can't contain other parts)."""
 
+    def _writeTransposed(self, seq):
+        """Alter the written pitch of transposing parts."""
+        toct, tnote, talter = self.transposition
+        # \transposition, which only affects MIDI output, sets the sounding
+        # pitch for written c'. We use it to cancel out the change in sounding
+        # pitch from \transpose, which affects both notation and MIDI output.
+        ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2),
+                     ly.dom.Transposition(seq))
+        stub = ly.dom.Command('transpose', seq)
+        ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2), stub)
+        ly.dom.Pitch(0, 0, 0, stub)
+        return ly.dom.Seqr(stub)
+
 
 
 class Container(Base):
@@ -109,16 +122,7 @@ class SingleVoicePart(Part):
         if self.clef:
             ly.dom.Clef(self.clef, seq)
         if self.transposition is not None:
-            toct, tnote, talter = self.transposition
-            if tnote or talter:
-                # use the appropriate key for non-octave transpositions
-                stub = ly.dom.Command('transpose', seq)
-                # the sounding pitch from PartData.assignMusic()...
-                ly.dom.Pitch(toct, tnote, fractions.Fraction(talter, 2), stub)
-                # ...becomes our written middle C
-                ly.dom.Pitch(0, 0, 0, stub)
-                # place the music within our \transpose block
-                seq = ly.dom.Seqr(stub)
+            seq = self._writeTransposed(seq)
         ly.dom.Identifier(a.name, seq)
         data.nodes.append(staff)
 
@@ -126,6 +130,8 @@ class SingleVoicePart(Part):
 class PianoStaffPart(Part):
     """Base class for parts creating a piano staff."""
     midiInstruments = ()  # may contain a list of MIDI instruments.
+    octave = 1  # for the right hand part; left is 1 octave lower.
+    transposition = None
 
     def createWidgets(self, layout):
         self.label = QLabel(wordWrap=True)
@@ -191,6 +197,8 @@ class PianoStaffPart(Part):
         c = ly.dom.Seqr(staff)
         if clef:
             ly.dom.Clef(clef, c)
+        if self.transposition is not None:
+            c = self._writeTransposed(c)
         if numVoices == 1:
             a = data.assignMusic(name, octave)
             ly.dom.Identifier(a.name, c)
@@ -220,12 +228,12 @@ class PianoStaffPart(Part):
         builder.setInstrumentNamesFromPart(p, self, data)
         s = ly.dom.Sim(p)
         # add two staves, with a respective number of voices.
-        self.buildStaff(data, builder, 'right', 1, self.upperVoices.value(), s)
+        self.buildStaff(data, builder, 'right', self.octave, self.upperVoices.value(), s)
         if (self.dynamicsStaff.isChecked()
             and self.upperVoices.value() and self.lowerVoices.value()):
             # both staffs have to be present to use this feature
             self.buildDynamicsStaff(data, s)
-        self.buildStaff(data, builder, 'left', 0, self.lowerVoices.value(), s, "bass")
+        self.buildStaff(data, builder, 'left', self.octave - 1, self.lowerVoices.value(), s, "bass")
         data.nodes.append(p)
 
 

--- a/frescobaldi_app/scorewiz/parts/brass.py
+++ b/frescobaldi_app/scorewiz/parts/brass.py
@@ -118,6 +118,57 @@ class Trombone(BrassPart):
     octave = -1
 
 
+class TromboneBb(Trombone):
+    @staticmethod
+    def title(_=_base.translate):
+        return _("Trombone in Bb")
+
+    @staticmethod
+    def short(_=_base.translate):
+        return _("abbreviation for Trombone in Bb", "Trb.Bb.")
+
+    # British brass band notation
+    clef = None
+    transposition = (-2, 6, -1)
+
+
+class AltoTrombone(Trombone):
+    @staticmethod
+    def title(_=_base.translate):
+        return _("Alto trombone")
+
+    @staticmethod
+    def short(_=_base.translate):
+        return _("abbreviation for Alto trombone", "A.Trb.")
+
+    clef = 'alto'
+    octave = 0
+
+
+class BassTrombone(Trombone):
+    @staticmethod
+    def title(_=_base.translate):
+        return _("Bass trombone")
+
+    @staticmethod
+    def short(_=_base.translate):
+        return _("abbreviation for Bass trombone", "B.Trb.")
+
+
+class TenorHorn(BrassPart):
+    @staticmethod
+    def title(_=_base.translate):
+        return _("Tenor horn")
+
+    @staticmethod
+    def short(_=_base.translate):
+        return _("abbreviation for Tenor horn", "T.Hn.")
+
+    midiInstrument = 'french horn'
+    octave = -1
+    transposition = (-1, 2, -1)
+
+
 class Baritone(BrassPart):
     @staticmethod
     def title(_=_base.translate):
@@ -156,7 +207,35 @@ class Tuba(BrassPart):
         return _("abbreviation for Tuba", "Tb.")
 
     midiInstrument = 'tuba'
+    clef = 'bass'
     octave = -1
+
+
+class TubaEb(Tuba):
+    @staticmethod
+    def title(_=_base.translate):
+        return _("Tuba in Eb")
+
+    @staticmethod
+    def short(_=_base.translate):
+        return _("abbreviation for Tuba in Eb", "Tb.Eb.")
+
+    # British brass band notation
+    clef = None
+    transposition = (-1, 2, -1)
+
+
+class TubaBb(Tuba):
+    @staticmethod
+    def title(_=_base.translate):
+        return _("Tuba in Bb")
+
+    @staticmethod
+    def short(_=_base.translate):
+        return _("abbreviation for Tuba in Bb", "Tb.Bb.")
+
+    # British brass band notation
+    clef = None
     transposition = (-2, 6, -1)
 
 
@@ -185,8 +264,14 @@ register(
         Flugelhorn,
         Mellophone,
         Trombone,
+        TromboneBb,
+        AltoTrombone,
+        BassTrombone,
+        TenorHorn,
         Baritone,
         Euphonium,
         Tuba,
+        TubaEb,
+        TubaBb,
         BassTuba,
     ])

--- a/frescobaldi_app/scorewiz/parts/brass.py
+++ b/frescobaldi_app/scorewiz/parts/brass.py
@@ -242,11 +242,11 @@ class TubaBb(Tuba):
 class BassTuba(BrassPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("Bass Tuba")
+        return _("Bass tuba")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Bass Tuba", "B.Tb.")
+        return _("abbreviation for Bass tuba", "B.Tb.")
 
     midiInstrument = 'tuba'
     clef = 'bass'

--- a/frescobaldi_app/scorewiz/parts/brass.py
+++ b/frescobaldi_app/scorewiz/parts/brass.py
@@ -40,6 +40,7 @@ class HornF(BrassPart):
         return _("abbreviation for Horn in F", "Hn.F.")
 
     midiInstrument = 'french horn'
+    octave = 0
     transposition = (-1, 3, 0)
 
 
@@ -99,6 +100,7 @@ class Mellophone(BrassPart):
         return _("abbreviation for Mellophone", "Mph.")
 
     midiInstrument = 'french horn'
+    octave = 0
     transposition = (-1, 3, 0)
 
 
@@ -154,6 +156,7 @@ class Tuba(BrassPart):
         return _("abbreviation for Tuba", "Tb.")
 
     midiInstrument = 'tuba'
+    octave = -1
     transposition = (-2, 6, -1)
 
 
@@ -168,8 +171,8 @@ class BassTuba(BrassPart):
 
     midiInstrument = 'tuba'
     clef = 'bass'
-    octave = -1
-    transposition = (-2, 0, 0)
+    octave = -2
+    transposition = (-1, 0, 0)
 
 
 register(

--- a/frescobaldi_app/scorewiz/parts/containers.py
+++ b/frescobaldi_app/scorewiz/parts/containers.py
@@ -56,6 +56,7 @@ class StaffGroup(_base.Container):
             (lambda: _("Square"), 'system_start_square'),
             ), self.systemStart, display=listmodel.translate_index(0),
             icon=lambda item: symbols.icon(item[1])))
+        self.systemStart.setCurrentIndex(1) # bracket
         self.systemStart.setIconSize(QSize(64, 64))
         self.connectBarLines = QCheckBox(checked=True)
 

--- a/frescobaldi_app/scorewiz/parts/containers.py
+++ b/frescobaldi_app/scorewiz/parts/containers.py
@@ -38,7 +38,7 @@ from . import register
 class StaffGroup(_base.Container):
     @staticmethod
     def title(_=_base.translate):
-        return _("Staff Group")
+        return _("Staff group")
 
     def accepts(self):
         return (StaffGroup, _base.Part)
@@ -67,7 +67,7 @@ class StaffGroup(_base.Container):
 
     def translateWidgets(self):
         self.systemStartLabel.setText(_("Type:"))
-        self.connectBarLines.setText(_("Connect Barlines"))
+        self.connectBarLines.setText(_("Connect barlines"))
         self.connectBarLines.setToolTip(_("If checked, barlines are connected between the staves."))
         self.systemStart.model().update()
 
@@ -147,7 +147,7 @@ class Score(_base.Group, scoreproperties.ScoreProperties):
 class BookPart(_base.Group):
     @staticmethod
     def title(_=_base.translate):
-        return _("Book Part")
+        return _("Book part")
 
     def accepts(self):
         return (Score, StaffGroup, _base.Part)
@@ -187,7 +187,7 @@ class Book(_base.Group):
             "<p>If you choose \"Suffix\" the entered name will be appended "
             "to the document's file name; if you choose \"Filename\", just "
             "the entered name will be used.</p>"))
-        self.bookOutputLabel.setText(_("Output Filename:"))
+        self.bookOutputLabel.setText(_("Output filename:"))
         self.bookOutputFileName.setText(_("Filename"))
         self.bookOutputSuffix.setText(_("Suffix"))
 

--- a/frescobaldi_app/scorewiz/parts/keyboard.py
+++ b/frescobaldi_app/scorewiz/parts/keyboard.py
@@ -144,6 +144,8 @@ class Celesta(KeyboardPart):
         return _("abbreviation for Celesta", "Cel.")
 
     midiInstrument = 'celesta'
+    octave = 2
+    transposition = (1, 0, 0)
 
 
 class SynthPart(KeyboardPart):

--- a/frescobaldi_app/scorewiz/parts/percussion.py
+++ b/frescobaldi_app/scorewiz/parts/percussion.py
@@ -61,6 +61,8 @@ class Xylophone(PitchedPercussionPart):
         return _("abbreviation for Xylophone", "Xyl.")
 
     midiInstrument = 'xylophone'
+    octave = 2
+    transposition = (1, 0, 0)
 
 
 class Marimba(_base.PianoStaffPart):
@@ -151,6 +153,8 @@ class Glockenspiel(PitchedPercussionPart):
         return _("abbreviation for Glockenspiel", "Gls.")
 
     midiInstrument = 'glockenspiel'
+    octave = 3
+    transposition = (2, 0, 0)
 
 
 class Carillon(_base.PianoStaffPart):

--- a/frescobaldi_app/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi_app/scorewiz/parts/plucked_strings.py
@@ -184,6 +184,11 @@ class TablaturePart(_base.Part):
             if self.tabFormat:
                 tabstaff.getWith()['tablatureFormat'] = ly.dom.Scheme(self.tabFormat)
             self.setTunings(tabstaff)
+            if self.midiInstruments:
+                builder.setMidiInstrument(tabstaff,
+                    self.midiInstrumentSelection.currentText())
+            else:
+                builder.setMidiInstrument(tabstaff, self.midiInstrument)
             sim = ly.dom.Simr(tabstaff)
             if numVoices == 1:
                 ly.dom.Identifier(assignments[0].name, sim)
@@ -198,7 +203,6 @@ class TablaturePart(_base.Part):
             p = staff
         elif staffType == 1:
             # only a TabStaff
-            builder.setMidiInstrument(tabstaff, self.midiInstrument)
             p = tabstaff
         else:
             # both TabStaff and normal staff

--- a/frescobaldi_app/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi_app/scorewiz/parts/plucked_strings.py
@@ -165,6 +165,8 @@ class TablaturePart(_base.Part):
             seq = ly.dom.Seqr(staff)
             if self.clef:
                 ly.dom.Clef(self.clef, seq)
+            if self.transposition is not None:
+                seq = self._writeTransposed(seq)
             mus = ly.dom.Simr(seq)
             for a in assignments[:-1]:
                 ly.dom.Identifier(a.name, mus)

--- a/frescobaldi_app/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi_app/scorewiz/parts/plucked_strings.py
@@ -318,7 +318,7 @@ class Guitar(TablaturePart):
         return _("abbreviation for Guitar", "Gt.")
 
     midiInstrument = 'acoustic guitar (nylon)'
-    clef = "treble_8"
+    transposition = (-1, 0, 0)
     tunings = (
         ('guitar-tuning', lambda: _("Guitar tuning")),
         ('guitar-seven-string-tuning', lambda: _("Guitar seven-string tuning")),
@@ -392,8 +392,9 @@ class AcousticBass(TablaturePart):
         return _("abbreviation for Acoustic bass", "A.Bs.") #FIXME
 
     midiInstrument = 'acoustic bass'
-    clef = 'bass_8'
+    clef = 'bass'
     octave = -2
+    transposition = (-1, 0, 0)
     tunings = (
         ('bass-tuning', lambda: _("Bass tuning")),
         ('bass-four-string-tuning', lambda: _("Four-string bass tuning")),

--- a/frescobaldi_app/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi_app/scorewiz/parts/plucked_strings.py
@@ -275,6 +275,7 @@ class Banjo(TablaturePart):
         return _("abbreviation for Banjo", "Bj.")
 
     midiInstrument = 'banjo'
+    transposition = (-1, 0, 0)
     tabFormat = 'fret-number-tablature-format-banjo'
     tunings = (
         ('banjo-open-g-tuning', lambda: _("Open G-tuning (aDGBD)")),

--- a/frescobaldi_app/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi_app/scorewiz/parts/plucked_strings.py
@@ -166,7 +166,7 @@ class TablaturePart(_base.Part):
             if self.clef:
                 ly.dom.Clef(self.clef, seq)
             if self.transposition is not None:
-                seq = self._writeTransposed(seq)
+                seq = self._transposeStaff(seq)
             mus = ly.dom.Simr(seq)
             for a in assignments[:-1]:
                 ly.dom.Identifier(a.name, mus)

--- a/frescobaldi_app/scorewiz/parts/special.py
+++ b/frescobaldi_app/scorewiz/parts/special.py
@@ -62,7 +62,7 @@ class Chords(_base.ChordNames, _base.Part):
 class BassFigures(_base.Part):
     @staticmethod
     def title(_=_base.translate):
-        return _("Figured Bass")
+        return _("Figured bass")
 
     def createWidgets(self, layout):
         self.extenderLines = QCheckBox()

--- a/frescobaldi_app/scorewiz/parts/strings.py
+++ b/frescobaldi_app/scorewiz/parts/strings.py
@@ -90,11 +90,11 @@ class Contrabass(StringPart):
 class BassoContinuo(Cello):
     @staticmethod
     def title(_=_base.translate):
-        return _("Basso Continuo")
+        return _("Basso continuo")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Basso Continuo", "B.c.")
+        return _("abbreviation for Basso continuo", "B.C.")
 
     def build(self, data, builder):
         super().build(data, builder)

--- a/frescobaldi_app/scorewiz/parts/strings.py
+++ b/frescobaldi_app/scorewiz/parts/strings.py
@@ -82,8 +82,9 @@ class Contrabass(StringPart):
         return _("abbreviation for Contrabass", "Cb.")
 
     midiInstrument = 'contrabass'
-    clef = 'bass_8'
+    clef = 'bass'
     octave = -2
+    transposition = (-1, 0, 0)
 
 
 class BassoContinuo(Cello):

--- a/frescobaldi_app/scorewiz/parts/woodwind.py
+++ b/frescobaldi_app/scorewiz/parts/woodwind.py
@@ -59,11 +59,11 @@ class Piccolo(WoodWindPart):
 class AltoFlute(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("Alto Flute")
+        return _("Alto flute")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation Alto flute", "Afl.")
+        return _("abbreviation for Alto flute", "A.Fl.")
 
     midiInstrument = 'flute'
     octave = 0
@@ -169,11 +169,11 @@ class Clarinet(WoodWindPart):
 class EflatClarinet(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("E-flat clarinet ")
+        return _("E-flat clarinet")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for E-flat Clarinet", "Cl. in Eb")
+        return _("abbreviation for E-flat clarinet", "Cl. in Eb")
 
     midiInstrument = 'clarinet'
     transposition = (0, 2, -1)
@@ -182,11 +182,11 @@ class EflatClarinet(WoodWindPart):
 class AClarinet(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("A clarinet ")
+        return _("A clarinet")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for A Clarinet", "Cl. in A")
+        return _("abbreviation for A clarinet", "Cl. in A")
 
     midiInstrument = 'clarinet'
     octave = 0
@@ -200,7 +200,7 @@ class BassClarinet(WoodWindPart):
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Bass clarinet", "BCl.")
+        return _("abbreviation for Bass clarinet", "B.Cl.")
 
     midiInstrument = 'clarinet'
     octave = -1
@@ -210,11 +210,11 @@ class BassClarinet(WoodWindPart):
 class C_MelodySax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("C-Melody Sax")
+        return _("C-melody saxophone")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for C-Melody Sax", "C-Mel Sax")
+        return _("abbreviation for C-melody saxophone", "C-Mel Sax")
 
     midiInstrument = 'soprano sax'
 
@@ -222,11 +222,11 @@ class C_MelodySax(WoodWindPart):
 class SopraninoSax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("Sopranino Sax")
+        return _("Sopranino saxophone")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Sopranino Sax", "SiSx.")
+        return _("abbreviation for Sopranino saxophone", "Si.Sax.")
 
     midiInstrument = 'soprano sax'
     transposition = (0, 2, -1)    # es'
@@ -235,11 +235,11 @@ class SopraninoSax(WoodWindPart):
 class SopranoSax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("Soprano Sax")
+        return _("Soprano saxophone")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Soprano Sax", "SoSx.")
+        return _("abbreviation for Soprano saxophone", "So.Sax.")
 
     midiInstrument = 'soprano sax'
     transposition = (-1, 6, -1)   # bes
@@ -248,11 +248,11 @@ class SopranoSax(WoodWindPart):
 class AltoSax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("Alto Sax")
+        return _("Alto saxophone")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Alto Sax", "ASx.")
+        return _("abbreviation for Alto saxophone", "A.Sax.")
 
     midiInstrument = 'alto sax'
     octave = 0
@@ -262,11 +262,11 @@ class AltoSax(WoodWindPart):
 class TenorSax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("Tenor Sax")
+        return _("Tenor saxophone")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Tenor Sax", "TSx.")
+        return _("abbreviation for Tenor saxophone", "T.Sax.")
 
     midiInstrument = 'tenor sax'
     octave = 0
@@ -276,11 +276,11 @@ class TenorSax(WoodWindPart):
 class BaritoneSax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("Baritone Sax")
+        return _("Baritone saxophone")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Baritone Sax", "BSx.")
+        return _("abbreviation for Baritone saxophone", "B.Sax.")
 
     midiInstrument = 'baritone sax'
     octave = -1
@@ -290,11 +290,11 @@ class BaritoneSax(WoodWindPart):
 class BassSax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("Bass Sax")
+        return _("Bass saxophone")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Bass Sax", "BsSx.")
+        return _("abbreviation for Bass saxophone", "Bs.Sax.")
 
     midiInstrument = 'baritone sax'
     octave = -1
@@ -308,7 +308,7 @@ class SopraninoRecorder(WoodWindPart):
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Sopranino recorder", "Si.rec.")
+        return _("abbreviation for Sopranino recorder", "Si.Rec.")
 
     midiInstrument = 'recorder'
     octave = 2
@@ -321,7 +321,7 @@ class SopranoRecorder(WoodWindPart):
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Soprano recorder", "S.rec.")
+        return _("abbreviation for Soprano recorder", "S.Rec.")
 
     midiInstrument = 'recorder'
     octave = 2
@@ -335,7 +335,7 @@ class AltoRecorder(WoodWindPart):
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Alto recorder", "A.rec.")
+        return _("abbreviation for Alto recorder", "A.Rec.")
 
     midiInstrument = 'recorder'
 
@@ -347,7 +347,7 @@ class TenorRecorder(WoodWindPart):
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Tenor recorder", "T.rec.")
+        return _("abbreviation for Tenor recorder", "T.Rec.")
 
     midiInstrument = 'recorder'
 
@@ -359,7 +359,7 @@ class BassRecorder(WoodWindPart):
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Bass recorder", "B.rec.")
+        return _("abbreviation for Bass recorder", "B.Rec.")
 
     midiInstrument = 'recorder'
     clef = 'bass'
@@ -370,11 +370,11 @@ class BassRecorder(WoodWindPart):
 class ContraBassRecorder(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("Contra Bass recorder")
+        return _("Contrabass recorder")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Contra Bass recorder", "Cb.rec.")
+        return _("abbreviation for Contrabass recorder", "Cb.Rec.")
 
     midiInstrument = 'recorder'
     clef = 'bass'
@@ -384,11 +384,11 @@ class ContraBassRecorder(WoodWindPart):
 class SubContraBassRecorder(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
-        return _("Subcontra Bass recorder")
+        return _("Subcontrabass recorder")
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Subcontra Bass recorder", "Scb.rec.")
+        return _("abbreviation for Subcontrabass recorder", "Scb.Rec.")
 
     midiInstrument = 'recorder'
     clef = 'bass'

--- a/frescobaldi_app/scorewiz/parts/woodwind.py
+++ b/frescobaldi_app/scorewiz/parts/woodwind.py
@@ -52,6 +52,7 @@ class Piccolo(WoodWindPart):
         return _("abbreviation for Piccolo", "Pic.")
 
     midiInstrument = 'piccolo'
+    octave = 2
     transposition = (1, 0, 0)
 
 
@@ -65,6 +66,7 @@ class AltoFlute(WoodWindPart):
         return _("abbreviation Alto flute", "Afl.")
 
     midiInstrument = 'flute'
+    octave = 0
     transposition = (-1, 4, 0)
 
 
@@ -78,6 +80,7 @@ class BassFlute(WoodWindPart):
         return _("abbreviation for Bass flute", "Bfl.")
 
     midiInstrument = 'flute'
+    octave = 0
     transposition = (-1, 0, 0)
 
 
@@ -103,6 +106,7 @@ class OboeDAmore(WoodWindPart):
         return _("abbreviation for Oboe d'amore", "Ob.d'am.")
 
     midiInstrument = 'oboe'
+    octave = 0
     transposition = (-1, 5, 0)
 
 
@@ -116,6 +120,7 @@ class EnglishHorn(WoodWindPart):
         return _("abbreviation for English horn", "Eng.h.")
 
     midiInstrument = 'english horn'
+    octave = 0
     transposition = (-1, 3, 0)
 
 
@@ -145,7 +150,7 @@ class ContraBassoon(WoodWindPart):
     midiInstrument = 'bassoon'
     transposition = (-1, 0, 0)
     clef = 'bass'
-    octave = -1
+    octave = -2
 
 
 class Clarinet(WoodWindPart):
@@ -184,6 +189,7 @@ class AClarinet(WoodWindPart):
         return _("abbreviation for A Clarinet", "Cl. in A")
 
     midiInstrument = 'clarinet'
+    octave = 0
     transposition = (-1, 5, 0)
 
 
@@ -197,6 +203,7 @@ class BassClarinet(WoodWindPart):
         return _("abbreviation for Bass clarinet", "BCl.")
 
     midiInstrument = 'clarinet'
+    octave = -1
     transposition = (-2, 6, -1)
 
 
@@ -248,6 +255,7 @@ class AltoSax(WoodWindPart):
         return _("abbreviation for Alto Sax", "ASx.")
 
     midiInstrument = 'alto sax'
+    octave = 0
     transposition = (-1, 2, -1)   # es
 
 
@@ -261,6 +269,7 @@ class TenorSax(WoodWindPart):
         return _("abbreviation for Tenor Sax", "TSx.")
 
     midiInstrument = 'tenor sax'
+    octave = 0
     transposition = (-2, 6, -1)   # bes,
 
 
@@ -274,6 +283,7 @@ class BaritoneSax(WoodWindPart):
         return _("abbreviation for Baritone Sax", "BSx.")
 
     midiInstrument = 'baritone sax'
+    octave = -1
     transposition = (-2, 2, -1)   # es,
 
 
@@ -287,6 +297,7 @@ class BassSax(WoodWindPart):
         return _("abbreviation for Bass Sax", "BsSx.")
 
     midiInstrument = 'baritone sax'
+    octave = -1
     transposition = (-3, 6, -1)   # bes,,
 
 
@@ -300,6 +311,7 @@ class SopraninoRecorder(WoodWindPart):
         return _("abbreviation for Sopranino recorder", "Si.rec.")
 
     midiInstrument = 'recorder'
+    octave = 2
     transposition = (1, 0, 0)
 
 class SopranoRecorder(WoodWindPart):
@@ -312,6 +324,7 @@ class SopranoRecorder(WoodWindPart):
         return _("abbreviation for Soprano recorder", "S.rec.")
 
     midiInstrument = 'recorder'
+    octave = 2
     transposition = (1, 0, 0)
 
 
@@ -349,9 +362,9 @@ class BassRecorder(WoodWindPart):
         return _("abbreviation for Bass recorder", "B.rec.")
 
     midiInstrument = 'recorder'
-    transposition = (1, 0, 0)
     clef = 'bass'
-    octave = -1
+    octave = 0
+    transposition = (1, 0, 0)
 
 
 class ContraBassRecorder(WoodWindPart):
@@ -379,7 +392,8 @@ class SubContraBassRecorder(WoodWindPart):
 
     midiInstrument = 'recorder'
     clef = 'bass'
-    octave = -1
+    octave = -2
+    transposition = (-1, 0, 0)
 
 
 

--- a/frescobaldi_app/scorewiz/parts/woodwind.py
+++ b/frescobaldi_app/scorewiz/parts/woodwind.py
@@ -77,7 +77,7 @@ class BassFlute(WoodWindPart):
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Bass flute", "Bfl.")
+        return _("abbreviation for Bass flute", "B.Fl.")
 
     midiInstrument = 'flute'
     octave = 0
@@ -103,7 +103,7 @@ class OboeDAmore(WoodWindPart):
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for Oboe d'amore", "Ob.d'am.")
+        return _("abbreviation for Oboe d'amore", "Ob.D'am.")
 
     midiInstrument = 'oboe'
     octave = 0
@@ -117,7 +117,7 @@ class EnglishHorn(WoodWindPart):
 
     @staticmethod
     def short(_=_base.translate):
-        return _("abbreviation for English horn", "Eng.h.")
+        return _("abbreviation for English horn", "Eng.H.")
 
     midiInstrument = 'english horn'
     octave = 0

--- a/frescobaldi_app/scorewiz/scoreproperties.py
+++ b/frescobaldi_app/scorewiz/scoreproperties.py
@@ -75,7 +75,9 @@ class ScoreProperties:
         All widgets must be present.
 
         """
-        self.lyKeySignature(node, builder)
+        # When entering at written pitch, the key signature is set per-part
+        if not (hasattr(self, 'transpositionMode') and self.transpositionMode == 'written'):
+            self.lyKeySignature(node, builder)
         self.lyTimeSignature(node, builder)
         self.lyPickup(node, builder)
         self.lyTempo(node, builder)
@@ -405,5 +407,10 @@ modes = (
     ('mixolydian',  lambda: _("Mixolydian")),
     ('aeolian',     lambda: _("Aeolian")),
     ('locrian',     lambda: _("Locrian")),
+)
+
+transpositionModes = (
+    ('written',     lambda: _("Written pitch")),
+    ('sounding',    lambda: _("Sounding pitch")),
 )
 

--- a/frescobaldi_app/scorewiz/settings.py
+++ b/frescobaldi_app/scorewiz/settings.py
@@ -45,12 +45,14 @@ class SettingsWidget(QWidget):
         self.generalPreferences = GeneralPreferences(self)
         self.lilyPondPreferences = LilyPondPreferences(self)
         self.instrumentNames = InstrumentNames(self)
+        self.transpositionPreferences = TranspositionPreferences(self)
         self.midiOutput = MidiOutput(self)
 
         grid.addWidget(self.scoreProperties, 0, 0)
         grid.addWidget(self.generalPreferences, 0, 1)
-        grid.addWidget(self.lilyPondPreferences, 1, 0, 2, 1)
+        grid.addWidget(self.lilyPondPreferences, 1, 0)
         grid.addWidget(self.instrumentNames, 1, 1)
+        grid.addWidget(self.transpositionPreferences, 2, 0)
         grid.addWidget(self.midiOutput, 2, 1)
 
     def clear(self):
@@ -388,6 +390,47 @@ class LilyPondPreferences(QGroupBox):
 
     def saveSettings(self):
         QSettings().setValue('scorewiz/lilypond/pitch_language', self.window().pitchLanguage())
+
+
+class TranspositionPreferences(QGroupBox):
+    def __init__(self, parent):
+        super().__init__(parent)
+
+        grid = QGridLayout()
+        self.setLayout(grid)
+
+        self.transpositionModeLabel = QLabel()
+        self.transpositionMode = QComboBox()
+        self.transpositionModeLabel.setBuddy(self.transpositionMode)
+
+        self.transpositionMode.setModel(listmodel.ListModel(
+            [label for (value, label) in scoreproperties.transpositionModes],
+            self.transpositionMode, display=listmodel.translate))
+
+        grid.addWidget(self.transpositionModeLabel, 0, 0)
+        grid.addWidget(self.transpositionMode, 0, 1)
+
+        app.translateUI(self)
+
+        self.loadSettings()
+        self.window().finished.connect(self.saveSettings)
+
+    def translateUI(self):
+        self.setTitle(_("Transposing instruments"))
+        self.transpositionModeLabel.setText(_("Enter music at:"))
+
+    def loadSettings(self):
+        s = QSettings()
+        s.beginGroup('scorewiz/transposition')
+        allow = [value for (value, label) in scoreproperties.transpositionModes]
+        tm = s.value('transpositionMode', '', str)
+        self.transpositionMode.setCurrentIndex(allow.index(tm) if tm in allow else 1)
+
+    def saveSettings(self):
+        s = QSettings()
+        s.beginGroup('scorewiz/transposition')
+        allow = [value for (value, label) in scoreproperties.transpositionModes]
+        s.setValue('transpositionMode', allow[self.transpositionMode.currentIndex()])
 
 
 paperSizes = ['', 'a3', 'a4', 'a5', 'a6', 'a7', 'legal', 'letter', '11x17']


### PR DESCRIPTION
This builds on my previous work in PR #1810, which standardizes handling of transposing instruments (see #1733 and #1800 for recent discussions).

Beware there are probably bugs in the current implementation. I have done some basic testing, but have not tried every possible combination of instrument and key signature. The code is also somewhat messier than I'd like, in part because entry at written pitch requires more things to know about the key signature and transposition settings.