### PR TITLE
Remove remaining pieces that depend on Poppler

### DIFF
--- a/frescobaldi/debuginfo.py
+++ b/frescobaldi/debuginfo.py
@@ -83,16 +83,6 @@ def qpageview_version():
     import qpageview
     return qpageview.version_string
 
-@_catch_unknown
-def poppler_version():
-    import popplerqt6
-    return '.'.join(format(n) for n in popplerqt6.poppler_version())
-
-@_catch_unknown
-def python_poppler_version():
-    import popplerqt6
-    return '.'.join(format(n) for n in popplerqt6.version())
-
 if platform.system() == "Darwin":
     @_catch_unknown
     def mac_installation_kind():
@@ -130,9 +120,6 @@ def version_info_named():
     yield "Qt", qt_version()
     yield "PyQt", pyqt_version()
     yield "qpageview", qpageview_version()
-    ## not used since the switch to PyQt6
-    #yield "poppler", poppler_version()
-    #yield "python-poppler-qt", python_poppler_version()
     yield "OS", operating_system()
     if platform.system() == 'Darwin':
         yield "installation kind", mac_installation_kind()

--- a/frescobaldi/install/update.py
+++ b/frescobaldi/install/update.py
@@ -37,9 +37,6 @@ def update(version):
     if version < 1:
         moveSettingsToNewRoot()
 
-    if version < 2:
-        moveArthurbackendPrint()
-
     if version < 3:
         renameUseshebang()
 
@@ -66,15 +63,6 @@ def moveSettingsToNewRoot():
             for k in keys:
                 s.setValue(k, o.value(k))
             o.clear()
-
-def moveArthurbackendPrint():
-    k = "arthurbackend_print"
-    oldk = "musicview/" + k
-    newk = "printing/" + k
-    s = QSettings()
-    if s.contains(oldk):
-        s.setValue(newk, s.value(oldk))
-        s.remove(oldk)
 
 def renameUseshebang():
     s = QSettings()

--- a/frescobaldi/musicview/__init__.py
+++ b/frescobaldi/musicview/__init__.py
@@ -20,12 +20,9 @@
 """
 The PDF preview panel.
 
-This file loads even if popplerqt6 is absent, although the PDF preview
-panel only shows a message about missing the popplerqt6 module.
-
 The widget module contains the real widget, the documents module a simple
-abstraction and caching of Poppler documents with their filename,
-and the printing module contains code to print a Poppler document, either
+abstraction and caching of PDF documents with their filenames,
+and the printing module contains code to print a PDF document, either
 via a PostScript rendering or by printing raster images to a QPrinter.
 
 All the point & click stuff is handled in the pointandclick module.
@@ -154,25 +151,6 @@ class MusicViewPanel(panel.Panel):
     @activate
     def printMusic(self):
         if self.widget().view.pageCount():
-            # warn about printing directly with cups on Mac
-            s = QSettings()
-            if (s.value("printing/directcups",
-                       False if platform.system() == "Darwin" else True, bool)
-                and platform.system() == "Darwin"):
-                from PyQt6.QtCore import QUrl
-                from PyQt6.QtWidgets import QMessageBox
-                result =  QMessageBox.warning(self.mainwindow(),
-                    _("Print Music"), _(
-                    "As per your settings, you are about to print the file "
-                    "directly to CUPS.\n"
-                    "This is discouraged on macOS, since in this case the "
-                    "settings of the system print window are ignored.\n"
-                    "You can disable it in Music Preferences.\n\n"
-                    "Do you really want to print to CUPS?\n\n"
-                    "(If you are unsure, the answer is likely no.)"),
-                    QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
-                if result == QMessageBox.StandardButton.No:
-                    return
             self.widget().view.print()
 
     @activate

--- a/frescobaldi/musicview/contextmenu.py
+++ b/frescobaldi/musicview/contextmenu.py
@@ -35,7 +35,7 @@ def show(position, panel, link, cursor):
 
     position: The global position to pop up
     panel: The music view panel, giving access to mainwindow and view widget
-    link: a popplerqt6 LinkBrowse instance or None
+    link: a qpageview Link instance or None
     cursor: a QTextCursor instance or None
 
     """

--- a/frescobaldi/musicview/pointandclick.py
+++ b/frescobaldi/musicview/pointandclick.py
@@ -37,12 +37,12 @@ import pointandclick
 from PyQt6.QtCore import QPointF, QRectF
 
 
-# cache point and click handlers for poppler documents
+# cache point and click handlers for PDF documents
 _cache = weakref.WeakKeyDictionary()
 
 
 def links(document):
-    # the backend (QPdf/poppler) object is replaced on every load
+    # the backend object is replaced on every load
     # of the pdf, which makes it a suitable cache key
     key = document.document()
 
@@ -63,7 +63,7 @@ def links(document):
 
 
 class Links(pointandclick.Links):
-    """Stores all the links of a Poppler document sorted by URL and text position.
+    """Stores all the links of a PDF document sorted by URL and text position.
 
     Only textedit:// urls are stored.
 

--- a/frescobaldi/preferences/musicviewers.py
+++ b/frescobaldi/preferences/musicviewers.py
@@ -67,9 +67,6 @@ class MusicView(preferences.Group):
         self.showShadow = QCheckBox(toggled=self.changed)
         layout.addWidget(self.showShadow, 0, 3)
 
-        self.arthurBackend = QCheckBox(toggled=self.changed)
-        layout.addWidget(self.arthurBackend, 1, 0, 1, 4)
-
         self.magnifierSizeLabel = QLabel()
         self.magnifierSizeSlider = QSlider(Qt.Orientation.Horizontal, valueChanged=self.changed)
         self.magnifierSizeSlider.setSingleStep(50)
@@ -78,9 +75,9 @@ class MusicView(preferences.Group):
         self.magnifierSizeSpinBox.setRange(pagedview.Magnifier.MIN_SIZE, pagedview.Magnifier.MAX_SIZE)
         self.magnifierSizeSpinBox.valueChanged.connect(self.magnifierSizeSlider.setValue)
         self.magnifierSizeSlider.valueChanged.connect(self.magnifierSizeSpinBox.setValue)
-        layout.addWidget(self.magnifierSizeLabel, 2, 0)
-        layout.addWidget(self.magnifierSizeSlider, 2, 1, 1, 2)
-        layout.addWidget(self.magnifierSizeSpinBox, 2, 3)
+        layout.addWidget(self.magnifierSizeLabel, 1, 0)
+        layout.addWidget(self.magnifierSizeSlider, 1, 1, 1, 2)
+        layout.addWidget(self.magnifierSizeSpinBox, 1, 3)
 
         self.magnifierScaleLabel = QLabel()
         self.magnifierScaleSlider = QSlider(Qt.Orientation.Horizontal, valueChanged=self.changed)
@@ -90,9 +87,9 @@ class MusicView(preferences.Group):
         self.magnifierScaleSpinBox.setRange(50, 800)
         self.magnifierScaleSpinBox.valueChanged.connect(self.magnifierScaleSlider.setValue)
         self.magnifierScaleSlider.valueChanged.connect(self.magnifierScaleSpinBox.setValue)
-        layout.addWidget(self.magnifierScaleLabel, 3, 0)
-        layout.addWidget(self.magnifierScaleSlider, 3, 1, 1, 2)
-        layout.addWidget(self.magnifierScaleSpinBox, 3, 3)
+        layout.addWidget(self.magnifierScaleLabel, 2, 0)
+        layout.addWidget(self.magnifierScaleSlider, 2, 1, 1, 2)
+        layout.addWidget(self.magnifierScaleSpinBox, 2, 3)
 
         app.translateUI(self)
 
@@ -106,11 +103,6 @@ class MusicView(preferences.Group):
         self.showShadow.setText(_("Shadow"))
         self.showShadow.setToolTip(_(
             "If checked, Frescobaldi draws a shadow around the pages."))
-        self.arthurBackend.setText(_("Use vector based backend (Arthur) for rendering PDF documents on screen (experimental!)"))
-        self.arthurBackend.setToolTip(_(
-            "If checked, Frescobaldi will use the Arthur backend of the Poppler\n"
-            "library for PDF rendering on screen. The Arthur backend is faster\n"
-            "than the default Splash backend, but more experimental."))
         self.setTitle(_("Display of Music"))
         self.magnifierSizeLabel.setText(_("Magnifier Size:"))
         self.magnifierSizeLabel.setToolTip(_(
@@ -133,8 +125,6 @@ class MusicView(preferences.Group):
         self.enableStrictPaging.setChecked(strictPaging)
         shadow = s.value("shadow", True, bool)
         self.showShadow.setChecked(shadow)
-        useArthur = s.value("arthurbackend", False, bool)
-        self.arthurBackend.setChecked(useArthur)
         self.magnifierSizeSlider.setValue(s.value("magnifier/size", 350, int))
         self.magnifierScaleSlider.setValue(round(s.value("magnifier/scalef", 3.0, float) * 100))
 
@@ -145,7 +135,6 @@ class MusicView(preferences.Group):
         s.setValue("show_scrollbars", self.showScrollbars.isChecked())
         s.setValue("strict_paging", self.enableStrictPaging.isChecked())
         s.setValue("shadow", self.showShadow.isChecked())
-        s.setValue("arthurbackend", self.arthurBackend.isChecked())
         s.setValue("magnifier/size", self.magnifierSizeSlider.value())
         s.setValue("magnifier/scalef", self.magnifierScaleSlider.value() / 100.0)
 
@@ -156,53 +145,27 @@ class Printing(preferences.Group):
 
         layout = QGridLayout()
         self.setLayout(layout)
-        self.printArthurBackend = QCheckBox(toggled=self.changed)
-        self.useCups = QCheckBox(toggled=self.changed)
         self.resolutionLabel = QLabel()
         self.resolution = QComboBox(editable=True, editTextChanged=page.changed)
         self.resolution.addItems("300 600 1200".split())
         self.resolution.lineEdit().setInputMask("9000")
 
-        layout.addWidget(self.printArthurBackend, 0, 0, 1, 2)
-        layout.addWidget(self.useCups, 1, 0, 1, 2)
-        layout.addWidget(self.resolutionLabel, 2, 0)
-        layout.addWidget(self.resolution, 2, 1)
+        layout.addWidget(self.resolutionLabel, 0, 0)
+        layout.addWidget(self.resolution, 0, 1)
 
         app.translateUI(self)
 
-        if not qpageview.cupsprinter.handle():
-            self.useCups.setEnabled(False)
-
     def translateUI(self):
         self.setTitle(_("Printing of Music"))
-        self.printArthurBackend.setText(_("Use vector based backend (Arthur) for printing PDF documents"))
-        self.printArthurBackend.setToolTip(_(
-            "If checked, Frescobaldi will use the Arthur backend of the Poppler\n"
-            "library for printing PDF documents. A big advantage of the Arthur backend\n"
-            "is that it is vector-based, in contrast to the default Splash backend,\n"
-            "which is raster-based. But Arthur is more experimental."))
-        self.useCups.setText(_("Print PDF documents directly to CUPS if available."))
-        self.useCups.setToolTip(_(
-            "If checked, Frescobaldi tries to print a PDF document directly using\n"
-            "the CUPS server, if available."))
         self.resolutionLabel.setText(_("Resolution:"))
         self.resolution.setToolTip(_(
             "Set the resolution if Frescobaldi prints using raster images."))
 
     def loadSettings(self):
         s = QSettings()
-        useArthurPrint = s.value("printing/arthurbackend_print", True, bool)
-        self.printArthurBackend.setChecked(useArthurPrint)
-        # see comment in pagedview and warning messages in musicview/__init__
-        # and viewers/__init__ for the rationale for the default value
-        self.useCups.setChecked(s.value("printing/directcups",
-                False if platform.system() == "Darwin" else True,
-                bool))
         with qutil.signalsBlocked(self.resolution):
             self.resolution.setEditText(format(s.value("printing/dpi", 300, int)))
 
     def saveSettings(self):
         s = QSettings()
-        s.setValue("printing/arthurbackend_print", self.printArthurBackend.isChecked())
-        s.setValue("printing/directcups", self.useCups.isChecked())
         s.setValue("printing/dpi", int(self.resolution.currentText()))

--- a/frescobaldi/userguide/prefs_musicviewers.md
+++ b/frescobaldi/userguide/prefs_musicviewers.md
@@ -1,14 +1,3 @@
 === Music Preferences ===
 
 Here you can configure how music is displayed and printed.
-
-You can configure whether to use the Arthur backend for music display and
-printing. For display it is not yet recommended, as the default Splash raster
-engine is more robust, but for printing Arthur is recommended, as it is
-vector-based rather than raster-based, which significantly improves printing
-quality.
-
-On systems that use the CUPS server, such as macOS and GNU/Linux, PDF's
-can be sent directly to the printer if you want to.
-
-The print resolution is only used when raster-based printing can't be avoided.

--- a/frescobaldi/viewers/__init__.py
+++ b/frescobaldi/viewers/__init__.py
@@ -19,11 +19,10 @@
 
 """
 The PDF preview panel.
-This file loads even if popplerqt6 is absent, although the PDF preview
-panel only shows a message about missing the popplerqt6 module.
+
 The widget module contains the real widget, the documents module a simple
-abstraction and caching of Poppler documents with their filename,
-and the printing module contains code to print a Poppler document, either
+abstraction and caching of PDF documents with their filenames,
+and the printing module contains code to print a PDF document, either
 via a PostScript rendering or by printing raster images to a QPrinter.
 All the point & click stuff is handled in the pointandclick module.
 
@@ -184,25 +183,6 @@ class AbstractViewPanel(panel.Panel):
     @activate
     def printMusic(self):
         if self.widget().view.pageCount():
-            # warn about printing directly with cups on Mac
-            s = QSettings()
-            if (s.value("printing/directcups",
-                       False if platform.system() == "Darwin" else True, bool)
-                and platform.system() == "Darwin"):
-                from PyQt6.QtCore import QUrl
-                from PyQt6.QtWidgets import QMessageBox
-                result =  QMessageBox.warning(self.mainwindow(),
-                    _("Print Music"), _(
-                    "As per your settings, you are about to print the file "
-                    "directly to CUPS.\n"
-                    "This is discouraged on macOS, since in this case the "
-                    "settings of the system print window are ignored.\n"
-                    "You can disable it in Music Preferences.\n\n"
-                    "Do you really want to print to CUPS?\n\n"
-                    "(If you are unsure, the answer is likely no.)"),
-                    QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
-                if result == QMessageBox.StandardButton.No:
-                    return
             self.widget().view.print()
 
     @activate

--- a/frescobaldi/viewers/abstractviewwidget.py
+++ b/frescobaldi/viewers/abstractviewwidget.py
@@ -31,10 +31,10 @@ class AbstractViewWidget(QWidget):
     # This serves as a stub for a future base class.
     # It will have to contain the complete interface for generic viewer
     # widgets and any implementation that is not specific to the viewer's
-    # technology (Poppler/QWebView or whatever).
+    # technology (QtPdf/QWebView or whatever).
     #
     # The idea is to have a consistent interface (with regard to toolbar,
     # navigation, contextmenu etc.) throughout all viewers
     #
-    # Currently all code is in AbstractPopplerWidget, but we will have to
+    # Currently all code is in AbstractPdfWidget, but we will have to
     # move as much as possible up to the current base class ASAP.

--- a/frescobaldi/viewers/manuscript/widget.py
+++ b/frescobaldi/viewers/manuscript/widget.py
@@ -22,12 +22,12 @@ The Manuscript viewer panel widget.
 """
 
 
-from viewers import popplerwidget
+from viewers import pdfwidget
 from . import contextmenu
 from . import toolbar
 import userguide.util
 
-class ManuscriptViewWidget(popplerwidget.AbstractPopplerWidget):
+class ManuscriptViewWidget(pdfwidget.AbstractPdfWidget):
     def __init__(self, panel):
         """Widget holding a manuscript view."""
         super().__init__(panel)

--- a/frescobaldi/viewers/pdfwidget.py
+++ b/frescobaldi/viewers/pdfwidget.py
@@ -19,10 +19,6 @@
 
 """
 Abstract base class for a PDF viewer widget.
-
-This widget originally used Poppler as the rendering backend.
-While this is no longer necessarily the case since switching to
-PyQt6, the class name is kept for backwards compatibility.
 """
 
 
@@ -55,7 +51,7 @@ from . import documents
 from . import pointandclick
 
 
-class AbstractPopplerWidget(abstractviewwidget.AbstractViewWidget):
+class AbstractPdfWidget(abstractviewwidget.AbstractViewWidget):
     """Widget containing the qpageview.View."""
 
     # TODO: As much as possible should be moved to the base class.

--- a/frescobaldi/viewers/pointandclick.py
+++ b/frescobaldi/viewers/pointandclick.py
@@ -37,7 +37,7 @@ import textedit
 import pointandclick
 
 
-# cache point and click handlers for poppler documents
+# cache point and click handlers for PDF documents
 _cache = weakref.WeakKeyDictionary()
 
 
@@ -59,7 +59,7 @@ def links(document):
 
 
 class Links(pointandclick.Links):
-    """Stores all the links of a Poppler document sorted by URL and text position.
+    """Stores all the links of a PDF document sorted by URL and text position.
 
     Only textedit:// urls are stored.
 

--- a/frescobaldi/viewers/popplerwidget.py
+++ b/frescobaldi/viewers/popplerwidget.py
@@ -18,7 +18,11 @@
 # See http://www.gnu.org/licenses/ for more information.
 
 """
-Abstract base class for a Poppler based viewer widget.
+Abstract base class for a PDF viewer widget.
+
+This widget originally used Poppler as the rendering backend.
+While this is no longer necessarily the case since switching to
+PyQt6, the class name is kept for backwards compatibility.
 """
 
 
@@ -59,7 +63,7 @@ class AbstractPopplerWidget(abstractviewwidget.AbstractViewWidget):
     zoomChanged = pyqtSignal(int, float) # mode, scale
 
     def __init__(self, panel):
-        """Creates the Poppler View for the panel."""
+        """Creates the PDF View for the panel."""
         super().__init__(panel)
         self.actionCollection = panel.actionCollection
         self.createProtectedFields()


### PR DESCRIPTION
This includes minor features like manually selecting a rendering backend or printing directly to CUPS. It also updates outdated references to Poppler in several comments and docstrings, and fully removes debugging information about the Poppler version that was previously commented out.

Removing these would allow us to completely drop Poppler support in qpageview as discussed under frescobaldi/qpageview#32.