### PR TITLE
Move slow operations to a background thread

### DIFF
--- a/frescobaldi_app/app.py
+++ b/frescobaldi_app/app.py
@@ -296,6 +296,25 @@ def job_queue():
         _job_queue = job.queue.GlobalJobQueue()
     return _job_queue
 
+
+_worker_thread = None
+
+def _stop_worker_thread():
+    if _worker_thread:
+        _worker_thread.quit()
+        _worker_thread.wait()
+
+def worker_thread():
+    """Return the global QThread object for background operations."""
+    global _worker_thread
+    if _worker_thread is None:
+        from PyQt6.QtCore import QThread
+        _worker_thread = QThread()
+        aboutToQuit.connect(_stop_worker_thread)
+        _worker_thread.start()
+    return _worker_thread
+
+
 _is_git_controlled = None
 
 def is_git_controlled():

--- a/frescobaldi_app/documentinfo.py
+++ b/frescobaldi_app/documentinfo.py
@@ -135,7 +135,7 @@ class DocumentInfo(locking.LockMixin, plugin.DocumentPlugin):
 
     def lydocinfo(self):
         """Return the lydocinfo instance for our document."""
-        with self.lock():
+        with self.lock(), locking.lock(self.document()):
             if self._lydocinfo is None:
                 doc = lydocument.Document(self.document())
                 v = variables.manager(self.document()).variables()
@@ -144,7 +144,7 @@ class DocumentInfo(locking.LockMixin, plugin.DocumentPlugin):
 
     def music(self):
         """Return the music.Document instance for our document."""
-        with self.lock():
+        with self.lock(), locking.lock(self.document()):
             if self._music is None:
                 import music
                 doc = lydocument.Document(self.document())

--- a/frescobaldi_app/highlighter.py
+++ b/frescobaldi_app/highlighter.py
@@ -40,6 +40,7 @@ import metainfo
 import plugin
 import variables
 import documentinfo
+import locking
 
 
 metainfo.define('highlighting', True)
@@ -136,6 +137,10 @@ class Highlighter(plugin.Plugin, QSyntaxHighlighter):
 
     def highlightBlock(self, text):
         """Called by Qt when the highlighting of the current line needs updating."""
+        with locking.lock(self.document()):
+            self._highlightBlock(text)
+
+    def _highlightBlock(self, text):
         # find the state of the previous line
         prev = self.previousBlockState()
         state = self._fridge.thaw(prev)

--- a/frescobaldi_app/locking.py
+++ b/frescobaldi_app/locking.py
@@ -1,0 +1,114 @@
+# This file is part of the Frescobaldi project, http://www.frescobaldi.org/
+#
+# Copyright (c) 2024 by Benjamin Johnson
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# See http://www.gnu.org/licenses/ for more information.
+
+"""
+Manages locking access across threads.
+"""
+
+from PyQt6.QtCore import QObject, QMutex
+
+
+class RLock(QObject):
+    """Reentrant lock using QMutex.
+
+    The first thread to acquire the lock becomes its owner,
+    which may then safely acquire it again. The lock's
+    "recursion level" respectively increases and decreases
+    each time the owner acquires or releases it. The lock is
+    unlocked when its "recursion level" reaches zero.
+
+    Other threads may acquire the lock once each. Acquiring
+    it again from a non-owning thread will cause deadlock.
+
+    The easiest way to use this is as a context manager for
+    the "with" statement.
+
+    This class is loosely modeled on the standard library's
+    threading.RLock, but omits most of the advanced features
+    that aren't needed by Frescobaldi.
+
+    """
+    def __init__(self):
+        super().__init__()
+        self._mutex = QMutex()
+        self._owner = None
+        self._count = 0
+
+    def acquire(self):
+        """Acquire the lock."""
+        thread = self.thread()
+        if self._owner is None:
+            self._mutex.lock()
+            self._owner = thread    # weakref won't work here
+            self._count = 1
+        elif thread == self._owner:
+            self._count += 1
+        else:
+            self._mutex.lock()
+
+    __enter__ = acquire
+
+    def release(self):
+        """Release the lock."""
+        thread = self.thread()
+        if thread == self._owner:
+            self._count -= 1
+            if self._count == 0:
+                self._owner = None
+                self._mutex.unlock()
+        else:
+            self._mutex.unlock()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.release()
+
+    def locked(self):
+        """Returns True if the lock is acquired."""
+        return self._count > 0
+
+
+class LockMixin:
+    """Mixin to add locking support to any class.
+
+    This provides a locking.RLock, accessed through the
+    lock() method, that you can use as a context manager
+    to make other methods thread-safe.
+
+    Add this mixin to classes whose instances may be
+    accessed simultaneously from multiple threads.
+
+    """
+    def lock(self):
+        """Returns a locking.RLock instance for this object.
+
+        Use the return value as a context manager in methods that
+        need to be thread-safe, like so:
+
+            def someProperty(self):
+                with self.lock():
+                    ...your logic goes here...
+
+        The lock is created the first time this method is called.
+
+        """
+        try:
+            return self._lock
+        except AttributeError:
+            self._lock = RLock()
+            return self._lock

--- a/frescobaldi_app/widgets/completer.py
+++ b/frescobaldi_app/widgets/completer.py
@@ -188,7 +188,8 @@ class Completer(QCompleter):
         self.autoCompleteLength characters selected.
 
         """
-        self._data.cursor = self.completionCursor()
+        # Copy the cursor so workers can manipulate it freely
+        self._data.cursor = QTextCursor(self.completionCursor())
         self._data.model = self.model()
         self._data.forced = forced
         self._data.popupVisible = self.popup().isVisible()

--- a/frescobaldi_app/worker.py
+++ b/frescobaldi_app/worker.py
@@ -1,0 +1,153 @@
+# This file is part of the Frescobaldi project, http://www.frescobaldi.org/
+#
+# Copyright (c) 2024 by Benjamin Johnson
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# See http://www.gnu.org/licenses/ for more information.
+
+"""
+Simple API for creating worker objects.
+
+Workers are used to run slow operations in a background thread.
+To create one, subclass Worker and implement your logic in its
+work() method. Upon successful completion, emit the resultReady
+signal to pass the results back to your initial thread.
+
+A worker is started by calling its start() class method with
+some data and the slot to be executed upon successful completion.
+There is a single instance of each worker type which is created
+the first time start() is called. You can also access the worker
+instance directly using its instance() class method, though it
+normally should not be necessary to do so.
+
+Because each worker type's one instance may have multiple users,
+a worker should not store state in its instance attributes.
+
+All workers live in the same thread, app.worker_thread(), which
+persists until the application exits. This reduces overhead
+compared to starting a new thread for each worker but does mean
+that workers may block one another.
+
+"""
+
+from PyQt6.QtCore import Qt, QObject, pyqtSignal
+
+import weakref
+
+import app
+
+
+_instances = weakref.WeakKeyDictionary()
+_starters = weakref.WeakKeyDictionary()
+
+
+class Worker(QObject):
+    """Base class for worker objects.
+
+    Subclass this and implement your logic in its work() method.
+
+    Use the instance() class method to get/create a Worker instance.
+
+    """
+    def work(self, data):
+        """Override this in your subclass to perform work.
+
+        Emit the resultReady signal upon successful completion to
+        pass the results back to the main thread.
+
+        """
+        pass
+
+    @classmethod
+    def instance(cls):
+        """Returns the instance of this worker type.
+
+        If it did not already exist, the worker is created, moved to
+        the global worker thread, and scheduled for deletion when that
+        thread exits.
+
+        """
+        try:
+            worker = _instances[cls]
+        except KeyError:
+            worker = _instances[cls] = cls()
+            worker.moveToThread(app.worker_thread())
+            app.worker_thread().finished.connect(worker.deleteLater)
+        return worker
+
+    @classmethod
+    def start(cls, data, onResultReady):
+        """Starts performing work.
+
+        The onResultReady argument is the slot that will be called
+        when the resultReady signal is emitted.
+
+        The worker is created if it did not already exist.
+
+        """
+        _Starter.instance(cls.instance()).start(data, onResultReady)
+
+    def _start(self, data, onResultReady):
+        try:
+            # We can't rely on a single-shot connection because it would
+            # still be connected next time if resultReady was not emitted.
+            # This way ensures only one slot is connected at a time.
+            self.resultReady.disconnect()
+        except TypeError:
+            pass    # no previous connection
+        self.resultReady.connect(onResultReady,
+                                 Qt.ConnectionType.QueuedConnection)
+        self.work(data)
+
+    # argument: result
+    resultReady = pyqtSignal('PyQt_PyObject')
+
+
+class _Starter(QObject):
+    """The thing that signals a worker to start.
+
+    To start a worker in another thread we have to use signals
+    and slots. This class exists so we don't have to connect and
+    emit those signals manually, which is especially handy in
+    classes like plugin.Plugin that are not derived from QObject.
+
+    Use the instance() class method to get/create the starter
+    instance for a given worker.
+
+    """
+    def __init__(self, worker):
+        super().__init__()
+        self._started.connect(worker._start,
+                              Qt.ConnectionType.QueuedConnection)
+
+    def start(self, data, onResultReady):
+        """Start the worker. See Worker.start()."""
+        self._started.emit(data, onResultReady)
+
+    @classmethod
+    def instance(cls, worker):
+        """Returns the starter instance for a worker.
+
+        The starter is created if it did not exist.
+
+        """
+        try:
+            starter = _starters[worker]
+        except KeyError:
+            starter = _starters[worker] = cls(worker)
+        return starter
+
+    # argument: data, onResultReady
+    _started = pyqtSignal('PyQt_PyObject', 'PyQt_PyObject')


### PR DESCRIPTION
This will either fix the infamous editor lag if I did it right or crash horribly if I didn't.

#473 identifies two slow, repeated operations that cause lag when editing large files: Updating the music position and building a model for autocompletion. While this lag is an old problem, it has gotten significantly worse under the Qt 6 port. This PR fixes the lag by moving the heavy processing for those operations into a separate thread as suggested in that issue. The threading is managed through a new worker API that can also be used for other slow operations if needed.

Now, about those horrible crashes. I believe my current implementation is robust, but I'd like to have a few more people test it before we consider committing. Threading introduces a lot of complexity, and I'll confess my early drafts of this did include some frankly silly thread safety mistakes. Maybe I shouldn't say that too loudly before I drive potential testers away. :)