### PR TITLE
Version 4.0.0: bump version and update the Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,25 @@ defined at the bottom of this file.
 
 All notable changes to the Frescobaldi project are documented in this file.
 
-## [Unreleased]
+## [4.0.0] - 2025-01-20
 
 ### Changed
 
-- Ported to PyQt6 (requires Qt >=6.6). (#1780)
+- Ported to PyQt6 (requires Qt >=6.6) (#1780).
+- Moved to current Python packaging tools (#1597, #1638).
+- Use standard gettext module (#1620).
+- Updated translations: French, German, Italian and Polish.
+
+### Added
+
+- Automatic installation of LilyPond (#1655).
+- Score Wizard improvements (#1690).
+- Korean translation (#1623).
+
+### Fixed
+
+- Docking/undocking panels on Wayland (Linux) is working again thanks to the Qt6 port.
+- Several minor bug fixes.
 
 
 ## [3.3.0] - 2023-03-26
@@ -1603,7 +1617,8 @@ README-translations.
 
 * Initial release.
 
-[unreleased]: https://github.com/frescobaldi/frescobaldi/compare/v3.3.0...master
+[unreleased]: https://github.com/frescobaldi/frescobaldi/compare/v4.0.0...master
+[4.0.0]: https://github.com/frescobaldi/frescobaldi/compare/v3.3.0...v4.0.0
 [3.3.0]: https://github.com/frescobaldi/frescobaldi/compare/v3.2...v3.3.0
 [3.2]: https://github.com/frescobaldi/frescobaldi/compare/v3.1.3...v3.2
 [3.1.3]: https://github.com/frescobaldi/frescobaldi/compare/v3.1.2...v3.1.3

--- a/frescobaldi_app/appinfo.py
+++ b/frescobaldi_app/appinfo.py
@@ -24,7 +24,7 @@ Information about the Frescobaldi application.
 
 # these variables are also used by the distutils setup
 name = "frescobaldi"
-version = "3.3.0"
+version = "4.0.0"
 extension_api = "0.9.0"
 description = "LilyPond Music Editor"
 long_description = \

--- a/linux/org.frescobaldi.Frescobaldi.metainfo.xml.in
+++ b/linux/org.frescobaldi.Frescobaldi.metainfo.xml.in
@@ -68,6 +68,7 @@
   <translation type="gettext">frescobaldi</translation>
 
   <releases>
+    <release version="4.0.0" date="2025-01-20" />
     <release version="3.3.0" date="2023-03-26" />
     <release version="3.2"   date="2022-05-05" />
     <release version="3.1.3" date="2020-12-26" />

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [{name = "Wilbert Berendsen", email = "info@frescobaldi.org"}]
 maintainers = [{name = "Wilbert Berendsen", email = "info@frescobaldi.org"}]
 license = {text = "GPL"}
 requires-python = ">=3.8"
-dependencies = ["pyqt6", "python-ly >= 0.9.5", "qpageview"]
+dependencies = ["pyqt6>=6.6", "python-ly >= 0.9.5", "qpageview>=1.0.0"]
 dynamic = ["version"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -29,6 +29,8 @@ classifiers = [
     "Natural Language :: Galician",
     "Natural Language :: German",
     "Natural Language :: Italian",
+    "Natural Language :: Japanese",
+    "Natural Language :: Korean",
     "Natural Language :: Polish",
     "Natural Language :: Portuguese (Brazilian)",
     "Natural Language :: Russian",
@@ -42,6 +44,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Multimedia :: Sound/Audio",
     "Topic :: Multimedia :: Graphics",
     "Topic :: Text Editors",


### PR DESCRIPTION
I put a release date (20th of January) in the Changelog just because I had to. We'll see when we manage to do it really.
