### PR TITLE
Switch to appstreamcli validate

### DIFF
--- a/linux/org.frescobaldi.Frescobaldi.metainfo.xml.in
+++ b/linux/org.frescobaldi.Frescobaldi.metainfo.xml.in
@@ -3,7 +3,6 @@
   <id>org.frescobaldi.Frescobaldi</id>
   <name>Frescobaldi</name>
   <summary>Write LilyPond music sheets</summary>
-  <icon type="stock">org.frescobaldi.Frescobaldi</icon>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
   <developer id="org.frescobaldi">

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ commands =
 description = Validate the Linux desktop/metainfo files. Run linux-generate before this.
 allowlist_externals =
   desktop-file-validate
-  appstream-util
+  appstreamcli
 commands =
   desktop-file-validate --no-hints linux/org.frescobaldi.Frescobaldi.desktop
-  appstream-util validate linux/org.frescobaldi.Frescobaldi.metainfo.xml
+  appstreamcli validate linux/org.frescobaldi.Frescobaldi.metainfo.xml


### PR DESCRIPTION
appstream-util validation is currently failing even if the metainfo file is correct.

Let's switch to appstreamcli, which is actively maintained and it's the tool used by Flathub...