### PR TITLE
Connect our aboutToQuit signal directly to qApp's

### DIFF
--- a/frescobaldi/app.py
+++ b/frescobaldi/app.py
@@ -132,6 +132,10 @@ def instantiate():
     QApplication.setOrganizationDomain(appinfo.domain)
     if platform.system() == "Darwin":
         qApp._menubar = QMenuBar()
+    # Our aboutToQuit provides more features than qApp's and is available
+    # to connect before qApp is initialized. Connecting our signal to qApp's
+    # this way ensures it is emitted before qApp is garbage collected.
+    qApp.aboutToQuit.connect(aboutToQuit.emit)
     appInstantiated()
 
 def oninit(func):
@@ -153,7 +157,6 @@ def oninit(func):
 def run():
     """Enter the Qt event loop."""
     result = qApp.exec()
-    aboutToQuit()
     return result
 
 def restart():


### PR DESCRIPTION
This is an attempt to solve problems particularly associated with macOS such as crashes on exit (#1868) or "object has been deleted" errors (#1467 and many others).

My hypothesis is that our non-Qt-based aboutToQuit signal is being emitted after qApp is garbage collected, so by the time its slots are called the objects they operate on no longer exist. This patch connects our signal directly to qApp's so it is instead called before qApp is destroyed. It also documents to the best of my understanding why we use a non-Qt-based signal in the first place.

If this works it may avoid the need for a more significant refactor like I've attempted under #1877.