### PR TITLE
Fix quoting env var and define secret in env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           - target: "macOS"
             output-format: "app"
             runs-on: "macos-latest"
-            briefcase-package-args: "--identity '$CERTIFICATE_ID'"
+            briefcase-package-args: '--identity "$CERTIFICATE_ID"'
             filename: dist/*.dmg
 
     steps:
@@ -109,6 +109,8 @@ jobs:
             ${{ matrix.briefcase-build-args }}
 
       - name: Package Frescobaldi
+        env:
+          CERTIFICATE_ID: ${{ secrets.CERTIFICATE_ID }}
         run: |
           ${{ matrix.briefcase-package-prefix }} \
           briefcase package \


### PR DESCRIPTION
This fixes the packaging step in the GitHub workflow for signing macOS apps.