### PR TITLE
Change default font in Windows, fixes issue #1894

### DIFF
--- a/frescobaldi/preferences/import_export.py
+++ b/frescobaldi/preferences/import_export.py
@@ -103,7 +103,7 @@ def importTheme(filename, widget, schemeWidget):
 
     fontElt = root.find('font')
 
-    defaultfont = "Lucida Console" if platform.system() == "Windows" else "monospace"
+    defaultfont = "Consolas" if platform.system() == "Windows" else "monospace"
     if fontElt.get('fontFamily') in QFontDatabase.families():
         fontFamily = fontElt.get('fontFamily')
     else:

--- a/frescobaldi/textformats.py
+++ b/frescobaldi/textformats.py
@@ -71,7 +71,7 @@ class TextFormatData:
         s.beginGroup("fontscolors/" + scheme)
 
         # load font
-        defaultfont = "Lucida Console" if platform.system() == "Windows" else "monospace"
+        defaultfont = "Consolas" if platform.system() == "Windows" else "monospace"
         self.font = QFont(s.value("fontfamily", defaultfont, str))
         self.font.setPointSizeF(s.value("fontsize", 10.0, float))
 


### PR DESCRIPTION
When in Windows, the default font is now Consolas.  Fixes issue #1894