### PR TITLE
Bump to version 4.0.1.dev1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ defined at the bottom of this file.
 
 All notable changes to the Frescobaldi project are documented in this file.
 
+## 4.0.1
+
+### Fixed
+
+- Bold fonts are now supported in Windows (#1902).
+
+
 ## [4.0.0] - 2025-03-29
 
 ### Changed

--- a/frescobaldi/appinfo.py
+++ b/frescobaldi/appinfo.py
@@ -24,7 +24,8 @@ Information about the Frescobaldi application.
 
 # these variables are also used by the distutils setup
 name = "frescobaldi"
-version = "4.0.0"
+# Use a PEP 440 compliant version number
+version = "4.0.1.dev1"
 extension_api = "0.9.0"
 description = "LilyPond Music Editor"
 long_description = \

--- a/linux/org.frescobaldi.Frescobaldi.metainfo.xml.in
+++ b/linux/org.frescobaldi.Frescobaldi.metainfo.xml.in
@@ -73,6 +73,7 @@
   <translation type="gettext">frescobaldi</translation>
 
   <releases>
+    <release version="4.0.1.dev1" type="development" date="2025-04-01" />
     <release version="4.0.0" date="2025-03-29" />
     <release version="3.3.0" date="2023-03-26" />
     <release version="3.2"   date="2022-05-05" />

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,11 +78,11 @@ bundle = "org.frescobaldi"
 # https://github.com/beeware/briefcase/issues/474
 version = "4.0.1.dev1"
 requires = [
-    "PyQt6==6.8.0",
-    "PyQt6-Qt6==6.8.1",
+    "PyQt6==6.8.1",
+    "PyQt6-Qt6==6.8.2",
     "PyQt6-sip==13.9.1",
     "PyQt6-WebEngine==6.8.0",
-    "PyQt6-WebEngine-Qt6==6.8.1",
+    "PyQt6-WebEngine-Qt6==6.8.2",
     "python-ly==0.9.9",
     "qpageview==1.0.0",
     "pygame==2.6.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,9 @@ attr = "frescobaldi.appinfo.version"
 [tool.briefcase]
 project_name = "Frescobaldi"
 bundle = "org.frescobaldi"
-version = "4.0.0"
+# Briefcase does not support dynamic version yet.
+# https://github.com/beeware/briefcase/issues/474
+version = "4.0.1.dev1"
 requires = [
     "PyQt6==6.8.0",
     "PyQt6-Qt6==6.8.1",


### PR DESCRIPTION
Bumping to a new .dev version right after a release will help us to easily distinguish an unreleased version.
Consider that we may ask users to install a package built from an open PR.

When we make the release we simply remove the .dev1 extension.
