### PR TITLE
Use Qt6 enums in MIDI input

### DIFF
--- a/frescobaldi/midiinput/elements.py
+++ b/frescobaldi/midiinput/elements.py
@@ -28,7 +28,7 @@ class Note:
         else:
             pitch = self._pitch
         # also octavecheck if Shift is held
-        return pitch.output(language) + (('='+ly.pitch.octaveToString(self._pitch.octave)) if QApplication.keyboardModifiers() & Qt.Modifier.SHIFT else '')
+        return pitch.output(language) + (('='+ly.pitch.octaveToString(self._pitch.octave)) if QApplication.keyboardModifiers() & Qt.KeyboardModifier.ShiftModifier else '')
 
     def midinote(self):
         return self._midinote


### PR DESCRIPTION
Fixes issue #1916

@bmjcode I found this bug while preparing a patch for the user manual. I want to add some instructions for MIDI playback and MIDI input.

I see that there are other `Qt.Modifier` uses in the code that should be probably modified? I'm not confident with Qt and programming in general...

```
git grep -n 'Qt\.Modifier' frescobaldi/
[...]
```

https://doc.qt.io/qt-6/qt.html#KeyboardModifier-enum
