### PR TITLE
Make mainwidget an instance attribute so it's not garbage-collected

### DIFF
--- a/frescobaldi/mainwindow.py
+++ b/frescobaldi/mainwindow.py
@@ -126,14 +126,15 @@ class MainWindow(QMainWindow):
 
         app.windows.append(self)
 
-        mainwidget = QWidget()
-        self.setCentralWidget(mainwidget)
+        self.mainwidget = QWidget()
+        self.setCentralWidget(self.mainwidget)
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
-        mainwidget.setLayout(layout)
+        self.mainwidget.setLayout(layout)
         self.tabBar = tabbar.TabBar(self)
         self.viewManager = viewmanager.ViewManager(self)
+        # Note layout.addWidget() changes the parent to self.mainwidget
         layout.addWidget(self.tabBar)
         layout.addWidget(self.viewManager)
 


### PR DESCRIPTION
Adding a widget to a layout [changes its parent](https://doc.qt.io/qt-6/layout.html#tips-for-using-layouts) to the widget on which the layout is installed. Here the layout is on `self.mainwidget`, and the tab bar and view manager become its children. Thus if `mainwidget` is a local variable, the tab bar and view manager are garbage-collected when the constructor returns and `mainwidget` goes out of scope, even though they were constructed with the `MainWindow` instance as their parent.

Hopefully this finally fixes the infamous https://github.com/frescobaldi/frescobaldi/issues/1467.