### PR TITLE
Add Qt version check

### DIFF
--- a/frescobaldi/appinfo.py
+++ b/frescobaldi/appinfo.py
@@ -46,6 +46,7 @@ desktop_file_name = "org.frescobaldi.Frescobaldi"
 # required versions of important dependencies
 required_python_version = (3, 8)
 required_python_ly_version = (0, 9, 4)
+required_qt_version = (6, 6)
 
 # LilyPond doc URLs to be used in lilydoc/manager.py
 # see also lilypondinfo.LilyPondInfo.lilydoc_url()

--- a/frescobaldi/checks.py
+++ b/frescobaldi/checks.py
@@ -78,6 +78,14 @@ if v < r:
         f"Frescobaldi is started with Python {v[0]}.{v[1]} \
 but requires at least version {r[0]}.{r[1]}.")
 
+# Check Qt version
+from PyQt6.QtCore import QLibraryInfo, QVersionNumber
+v = QLibraryInfo.version()
+r = QVersionNumber(*appinfo.required_qt_version)
+if v < r:
+    error("Qt version is too old.",
+        f"Frescobaldi is started with Qt {v.toString()} \
+but requires at least version {r.toString()}.")
 
 # Check qpageview availability
 if importlib.util.find_spec('qpageview') is None:


### PR DESCRIPTION
If Qt version is below the required version (currently 6.6), the following error window will appear:

![image](https://github.com/user-attachments/assets/276de42e-4718-4ff5-9344-1fa24766f806)

and the user will be forced to quit Frescobaldi.
