### PR TITLE
Block further method calls if we encounter a RuntimeError

### DIFF
--- a/frescobaldi/musicpos.py
+++ b/frescobaldi/musicpos.py
@@ -74,8 +74,12 @@ class MusicPosition(plugin.ViewSpacePlugin):
         """Called when one of the timers fires."""
         view = self._view()
         if view:
-            d = view.document()
-            c = view.textCursor()
+            try:
+                d = view.document()
+                c = view.textCursor()
+            except RuntimeError:
+                # This happens if the window is closed before the timer fires
+                return
             import documentinfo
             m = documentinfo.music(d)
             import ly.duration

--- a/frescobaldi/signals.py
+++ b/frescobaldi/signals.py
@@ -305,7 +305,11 @@ class MethodListener(ListenerBase):
     def call(self, args, kwargs):
         obj = self.obj()
         if obj is not None:
-            return self.func(obj, *args[self.argslice], **kwargs)
+            try:
+                return self.func(obj, *args[self.argslice], **kwargs)
+            except RuntimeError:
+                # PyQt raises this if the underlying C++ object is deleted
+                self.obj = None
 
 
 class FunctionListener(ListenerBase):


### PR DESCRIPTION
This fixes instances of #1467 where a PyQt object's underlying C++ object is deleted before the Python object is garbage-collected.