### PR TITLE
Add Ctrl+, shortcut to open the Preferences

### DIFF
--- a/frescobaldi/mainwindow.py
+++ b/frescobaldi/mainwindow.py
@@ -1316,7 +1316,9 @@ class ActionCollection(actioncollection.ActionCollection):
         self.edit_find_next.setShortcuts(QKeySequence.StandardKey.FindNext)
         self.edit_find_previous.setShortcuts(QKeySequence.StandardKey.FindPrevious)
         self.edit_replace.setShortcuts(QKeySequence.StandardKey.Replace)
-        self.edit_preferences.setShortcuts(QKeySequence.StandardKey.Preferences)
+        # QKeySequence.StandardKey.Preferences currently has no defaults on Windows and GNOME.
+        # Let's force Ctrl+, (default on macOS and GNOME guidelines) for all platforms.
+        self.edit_preferences.setShortcut(QKeySequence(Qt.Modifier.CTRL | Qt.Key.Key_Comma))
 
         if platform.system() == "Darwin":
             self.view_next_document.setShortcut(QKeySequence(Qt.Modifier.META | Qt.Key.Key_Tab))


### PR DESCRIPTION
GNOME and Windows¹ do not have a standard keyboard shortcut to open the Preferences so there's no default shortcut in these platforms. We can force Ctrl+, which is the default on macOS but it's also very common on some popular crossplatform editors.

This is a partial fix for #887

¹ https://doc.qt.io/qt-6/qkeysequence.html#standard-shortcuts