### PR TITLE
QFontComboBox does not have a FontDialogOption attribute

### DIFF
--- a/frescobaldi/fonts/oldfontsdialog.py
+++ b/frescobaldi/fonts/oldfontsdialog.py
@@ -47,7 +47,7 @@ class DocumentFontsDialog(widgets.dialog.Dialog):
         self.sansLabel = QLabel()
         self.sansCombo = QFontComboBox()
         self.typewriterLabel = QLabel()
-        self.typewriterCombo = QFontComboBox(fontFilters=QFontComboBox.FontDialogOption.MonospacedFonts)
+        self.typewriterCombo = QFontComboBox(fontFilters=QFontComboBox.FontFilter.MonospacedFonts)
 
         layout.addWidget(self.romanLabel, 0, 0)
         layout.addWidget(self.romanCombo, 0, 1, 1, 2)


### PR DESCRIPTION
Yet another overseen Qt6 change.
Fix issue #1954