### PR TITLE
Fix "TypeError: 'NoneType' object is not callable" in signals.py

### DIFF
--- a/frescobaldi/signals.py
+++ b/frescobaldi/signals.py
@@ -303,8 +303,8 @@ class MethodListener(ListenerBase):
         return self.__class__ is other.__class__ and self.objid == other.objid and self.func is other.func
 
     def call(self, args, kwargs):
-        obj = self.obj()
-        if obj is not None:
+        if self.obj is not None:
+            obj = self.obj()
             try:
                 return self.func(obj, *args[self.argslice], **kwargs)
             except RuntimeError:


### PR DESCRIPTION
This fixes #1956.