### PR TITLE
Set an explicit default font on macOS

### DIFF
--- a/frescobaldi/preferences/import_export.py
+++ b/frescobaldi/preferences/import_export.py
@@ -103,7 +103,12 @@ def importTheme(filename, widget, schemeWidget):
 
     fontElt = root.find('font')
 
-    defaultfont = "Consolas" if platform.system() == "Windows" else "monospace"
+    if platform.system() == "Darwin":   # macOS
+        defaultfont = "Monaco"
+    elif platform.system() == "Windows":
+        defaultfont = "Consolas"
+    else:
+        defaultfont = "monospace"
     if fontElt.get('fontFamily') in QFontDatabase.families():
         fontFamily = fontElt.get('fontFamily')
     else:

--- a/frescobaldi/textformats.py
+++ b/frescobaldi/textformats.py
@@ -71,7 +71,12 @@ class TextFormatData:
         s.beginGroup("fontscolors/" + scheme)
 
         # load font
-        defaultfont = "Consolas" if platform.system() == "Windows" else "monospace"
+        if platform.system() == "Darwin":   # macOS
+            defaultfont = "Monaco"
+        elif platform.system() == "Windows":
+            defaultfont = "Consolas"
+        else:
+            defaultfont = "monospace"
         self.font = QFont(s.value("fontfamily", defaultfont, str))
         self.font.setPointSizeF(s.value("fontsize", 10.0, float))
 


### PR DESCRIPTION
When I had a chance to briefly test Frescobaldi on a Mac, I noticed the editor font defaulted to the system sans-serif font. This PR explicitly sets a monospace default font on macOS to match the behavior on other platforms.

Do any of our Mac users have a preference for which font? I assume Monaco is the safest choice since it's been in every macOS version, but it looks like Apple favors other fonts in recent OS versions.