### PR TITLE
Make removeDocument() fail safely if there is no document to remove

### DIFF
--- a/frescobaldi/historymanager.py
+++ b/frescobaldi/historymanager.py
@@ -55,6 +55,9 @@ class HistoryManager:
         self._documents.insert(-1, doc)
 
     def removeDocument(self, doc):
+        if doc not in self._documents:
+            # e.g. calling setCurrentDocument() when self._documents is empty
+            return
         active = doc is self._documents[-1]
         if active:
             if len(self._documents) > 1:


### PR DESCRIPTION
This fixes `ValueError: list.remove(x): x not in list` as reported in multiple issues (#1324, #1914, #1972, and many duplicates).