### PR TITLE
Use Pygame Community Edition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [{name = "Wilbert Berendsen", email = "info@frescobaldi.org"}]
 maintainers = [{name = "Wilbert Berendsen", email = "info@frescobaldi.org"}]
 license = {text = "GPL-2.0-or-later"}
 requires-python = ">=3.8"
-dependencies = ["pyqt6>=6.6", "python-ly >= 0.9.5", "qpageview>=1.0.0", "PyQt6-WebEngine", "pygame"]
+dependencies = ["pyqt6>=6.6", "python-ly >= 0.9.5", "qpageview>=1.0.0", "PyQt6-WebEngine", "pygame-ce"]
 dynamic = ["version"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -90,7 +90,7 @@ requires = [
     "PyQt6-WebEngine-Qt6==6.9.0",
     "python-ly==0.9.9",
     "qpageview==1.0.0",
-    "pygame==2.6.1"
+    "pygame-ce==2.5.3"  # https://github.com/pygame-community/pygame-ce/issues/3468
 ]
 
 [tool.briefcase.app.frescobaldi]


### PR DESCRIPTION
This fork re-enables MIDI output on macOS.
Fix #1946