### PR TITLE
Fix an exception caused by renamed enums in the Quick Insert panel

### DIFF
--- a/frescobaldi/quickinsert/buttongroup.py
+++ b/frescobaldi/quickinsert/buttongroup.py
@@ -26,7 +26,7 @@ A QGroupBox in the Quick Insert Panel that auto-layouts its buttons.
 import weakref
 
 from PyQt6.QtCore import QEvent, QSize
-from PyQt6.QtGui import QAction, QKeySequence
+from PyQt6.QtGui import QAction, QKeySequence, QTextCursor
 from PyQt6.QtWidgets import (
     QGridLayout, QGroupBox, QMenu, QToolButton, QToolTip)
 
@@ -145,7 +145,7 @@ class ButtonGroup(QGroupBox):
         pos = cursor.selectionStart()
         cursor.insertText(text)
         if indent and '\n' in text:
-            cursor.setPosition(pos, cursor.KeepAnchor)
+            cursor.setPosition(pos, QTextCursor.MoveMode.KeepAnchor)
             import indent
             with cursortools.compress_undo(cursor, True):
                 indent.re_indent(cursor)

--- a/frescobaldi/quickinsert/spanners.py
+++ b/frescobaldi/quickinsert/spanners.py
@@ -262,7 +262,7 @@ class GraceGroup(buttongroup.ButtonGroup):
                         after.setPosition(pos)
                         after.setPosition(end, QTextCursor.MoveMode.KeepAnchor)
                     except IndexError:
-                        after.movePosition(cursor.EndOfLine)
+                        after.movePosition(QTextCursor.MoveOperation.EndOfLine)
                     after.insertText(outer[1])
                     cursor.insertText(outer[0])
 


### PR DESCRIPTION
Fixes #2004.