### PR TITLE
Remove pygame from project.dependencies

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,17 +57,18 @@ You will also need a few packages from your operating system:
 * Git, the version control software used for Frescobaldi's source code,
 * GNU Gettext, a suite of tools for working with translations, for generating
   compiled MO catalogs.
+* [PortMidi](https://github.com/PortMidi/portmidi), for MIDI playback.
 
 On Debian/Ubuntu, these packages can be installed using:
 
 ```
-sudo apt install pipx tox git gettext
+sudo apt install pipx tox git gettext libportmidi0
 ```
 
 On Fedora:
 
 ```
-sudo dnf install pipx tox git gettext
+sudo dnf install pipx tox git gettext portmidi
 ```
 
 PyQt6 dependencies will be automatically installed from PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,13 @@ authors = [{name = "Wilbert Berendsen", email = "info@frescobaldi.org"}]
 maintainers = [{name = "Wilbert Berendsen", email = "info@frescobaldi.org"}]
 license = {text = "GPL-2.0-or-later"}
 requires-python = ">=3.8"
-dependencies = ["pyqt6>=6.6", "python-ly >= 0.9.5", "qpageview>=1.0.0", "PyQt6-WebEngine", "pygame-ce"]
+# Do not add pygame dependency
+dependencies = [
+  "pyqt6>=6.6",
+  "pyqt6-webengine",
+  "python-ly >= 0.9.5",
+  "qpageview>=1.0.0"
+]
 dynamic = ["version"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Let the user/packager decide the tool for MIDI playback.

On Linux the preferred choice is probably PortMidi installed as a system package.
An alternative is pygame from PyPI, but it currently works fine on Linux and Windows only, while macOS needs pygame-ce (community fork).

Discussed here:
https://github.com/frescobaldi/frescobaldi/pull/1939#issuecomment-2966386546