### PR TITLE
New issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-issue.md
+++ b/.github/ISSUE_TEMPLATE/new-issue.md
@@ -1,0 +1,27 @@
+---
+name: New Issue
+about: Create a bug report or feature request
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Check the Issues list**
+Before opening a new issue please [check if it's been reported already](https://github.com/frescobaldi/frescobaldi/issues/).
+
+**Describe the bug**
+A clear and concise description of what the bug or feature request is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+Please paste the content of **Help>About Frescobaldi>Version**:
+
+```
+
+```


### PR DESCRIPTION
As discussed in #2008, using a default template for new issues might help reducing the issue duplication.