### PR TITLE
Fix ruff E722, no bare excepts

### DIFF
--- a/frescobaldi/signals.py
+++ b/frescobaldi/signals.py
@@ -238,7 +238,7 @@ class SignalContext(Signal):
                 m.__enter__()
                 exits.append(m.__exit__)
             yield
-        except:
+        except Exception:
             exc = sys.exc_info()
         finally:
             while exits:
@@ -246,7 +246,7 @@ class SignalContext(Signal):
                 try:
                     if exit(*exc):
                         exc = (None, None, None)
-                except:
+                except Exception:
                     exc = sys.exc_info()
             if exc != (None, None, None):
                 raise # exc[0], exc[1], exc[2]


### PR DESCRIPTION
Fix two instances of bare excepts:

    $ ruff check --select E722
    All checks passed!
