### PR TITLE
vbcl: cover with unit test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+on:
+  - push
+  - pull_request
+
+jobs:
+  pytest:
+    name: Run pytest tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install .[test]
+      - name: Run tests
+        run: pytest

--- a/frescobaldi/vbcl/__init__.py
+++ b/frescobaldi/vbcl/__init__.py
@@ -34,15 +34,14 @@ list_items_end = re.compile(r"^\s*\]")
 
 def check_mandatory_keys(d, mandatory_keys):
     """Check if all mandatory keys are present. Raise a ValueError if not."""
-    if mandatory_keys:
-        missing = []
-        for key in mandatory_keys:
-            if not key in d.keys():
-                missing.append(key)
-        if missing:
-            raise ValueError(
-                _("VBCL Error: Missing mandatory key(s) '{keys}'").format(
-                    keys=', '.join(missing)))
+    missing = []
+    for key in mandatory_keys:
+        if not key in d.keys():
+            missing.append(key)
+    if missing:
+        raise ValueError(
+            _("VBCL Error: Missing mandatory key(s) '{keys}'").format(
+                keys=', '.join(missing)))
 
 
 def set_defaults(d, defaults):

--- a/frescobaldi/vbcl/__init__.py
+++ b/frescobaldi/vbcl/__init__.py
@@ -51,10 +51,10 @@ def set_defaults(d, defaults):
         d[key] = d.get(key, defaults[key])
 
 
-def parse(lines, mandatory_keys=[], defaults={}):
+def parse(text, mandatory_keys=[], defaults={}):
     """Returns a dictionary corresponding to a parsed VBCL string list."""
     d = dict()
-    it = iter(lines)
+    it = iter(text.split('\n'))
 
     try:
         while True:
@@ -105,5 +105,5 @@ def parse_file(filename, mandatory_keys=[], defaults={}):
     Raises an exception if the given file doesn't exist or isn't readable"""
 
     with open(filename, encoding='utf-8') as f:
-        cfg_dict = parse(f.read().split('\n'), mandatory_keys, defaults)
+        cfg_dict = parse(f.read(), mandatory_keys, defaults)
         return cfg_dict

--- a/frescobaldi/vbcl/__init__.py
+++ b/frescobaldi/vbcl/__init__.py
@@ -51,7 +51,7 @@ def set_defaults(d, defaults):
         d[key] = d.get(key, defaults[key])
 
 
-def parse(lines, mandatory_keys, defaults):
+def parse(lines, mandatory_keys=[], defaults={}):
     """Returns a dictionary corresponding to a parsed VBCL string list."""
     d = dict()
     it = iter(lines)
@@ -100,7 +100,7 @@ def parse(lines, mandatory_keys, defaults):
     return d
 
 
-def parse_file(filename, mandatory_keys=None, defaults=None):
+def parse_file(filename, mandatory_keys=[], defaults={}):
     """Returns a dictionary corresponding to a parsed VBCL config file.
     Raises an exception if the given file doesn't exist or isn't readable"""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,11 @@ Repository = "https://github.com/frescobaldi/frescobaldi"
 [project.scripts]
 frescobaldi = "frescobaldi.__main__:main"
 
+[project.optional-dependencies]
+test = [
+    "pytest>=8.3",
+]
+
 [tool.hatch.version]
 path = "frescobaldi/appinfo.py"
 pattern = "version = \"(?P<version>.*)\""
@@ -126,6 +131,9 @@ description = "LilyPond included file"
 extension = "ily"
 icon = "frescobaldi/icons/org.frescobaldi.Frescobaldi"
 url = "https://lilypond.org/"
+
+[tool.pytest.ini_options]
+pythonpath = ["frescobaldi"]
 
 [tool.ruff]
 # _ is currently added to builtins, so ruff can't find where it's defined.

--- a/tests/vbcl/test_vbcl.py
+++ b/tests/vbcl/test_vbcl.py
@@ -1,9 +1,58 @@
 import pytest
 
+# global function _() is required by the vbcl module
+import i18n
+i18n.install('en')
+
 from vbcl import *
+
+def test_empty_file():
+    assert parse_file('/dev/null') == {}
 
 def test_empty():
     assert parse('') == {}
 
-def test_empty_file():
-    assert parse_file('/dev/null') == {}
+def test_empty_with_defaults():
+    assert parse('', defaults={'key': '1'}) == {'key': '1'}
+
+def test_mandatory_key_missing():
+    with pytest.raises(ValueError, match=r'VBCL Error: Missing mandatory key'):
+        parse('', mandatory_keys=['key'])
+
+def test_comment():
+    assert parse('# this is a comment') == {}
+
+def test_one_line_value():
+    assert parse('key: my value') == {'key': 'my value'}
+
+def test_long_value():
+    assert parse("key: <\nLong\ntext value\n>") == {'key': "Long\ntext value"}
+
+def test_list():
+    assert parse("key: [\napples\n]") == {'key': ['apples']}
+    assert parse("key: [\napples\nbananas\n]") == {'key': ['apples', 'bananas']}
+
+def test_full_example():
+    config = '''
+# this is a comment
+
+extension-name: Sample Extension
+description: <
+  Long
+  text value
+  spanning multiple lines
+  >
+dependencies: [
+  boilerplate
+]
+version: 0.0.1
+    '''
+
+    expected = {
+        'extension-name': 'Sample Extension',
+        'description': "Long\ntext value\nspanning multiple lines",
+        'dependencies': ['boilerplate'],
+        'version': '0.0.1'
+    }
+
+    assert parse(config) == expected

--- a/tests/vbcl/test_vbcl.py
+++ b/tests/vbcl/test_vbcl.py
@@ -21,16 +21,27 @@ def test_mandatory_key_missing():
 
 def test_comment():
     assert parse('# this is a comment') == {}
+    assert parse('  # this is a comment') == {}
 
 def test_one_line_value():
     assert parse('key: my value') == {'key': 'my value'}
 
+def test_comment_after_value():
+    # comments at the end of meaningful lines are not supported
+    assert parse('key: my value # not a comment') == {'key': 'my value # not a comment'}
+
 def test_long_value():
     assert parse("key: <\nLong\ntext value\n>") == {'key': "Long\ntext value"}
+
+def test_long_value_whitespace():
+    assert parse("key: <  \n  Long  \n  \n  text value  \n  >  \n") == {'key': "Long\n\ntext value"}
 
 def test_list():
     assert parse("key: [\napples\n]") == {'key': ['apples']}
     assert parse("key: [\napples\nbananas\n]") == {'key': ['apples', 'bananas']}
+
+def test_list_whitespace():
+    assert parse("key: [  \n  apples  \n  \n  bananas  \n  ]  \n") == {'key': ['apples', '', 'bananas']}
 
 def test_full_example():
     config = '''

--- a/tests/vbcl/test_vbcl.py
+++ b/tests/vbcl/test_vbcl.py
@@ -1,0 +1,9 @@
+import pytest
+
+from vbcl import *
+
+def test_empty():
+    assert parse('') == {}
+
+def test_empty_file():
+    assert parse_file('/dev/null') == {}


### PR DESCRIPTION
In #2015 the `frescobaldi/vbcl/__init__.py` is mentioned as hard to test (manually).

Since the module is pure functional logic, let's cover it with unit tests, refactor boldly and never be worried again.

(I picked `pytest` because that's what I use by default. I'm not opposed to switching to any other testing tool.)