### PR TITLE
Modifications to remove unused variables

### DIFF
--- a/frescobaldi/autocomplete/analyzer.py
+++ b/frescobaldi/autocomplete/analyzer.py
@@ -231,7 +231,7 @@ class Analyzer:
     def midi_instrument(self):
         """Complete midiInstrument = #"... """
         try:
-            i = self.tokens.index('midiInstrument', -7, -2)
+            self.tokens.index('midiInstrument', -7, -2)
         except ValueError:
             return
         if self.last != '"':
@@ -241,7 +241,7 @@ class Analyzer:
     def font_name(self):
         """Complete #'font-name = #"..."""
         try:
-            i = self.tokens.index('font-name', -7, -3)
+            self.tokens.index('font-name', -7, -3)
         except ValueError:
             return
         if self.last != '"':
@@ -437,7 +437,6 @@ class Analyzer:
         except ValueError:
             return
         self.backuntil(lx.Space, lp.DotPath)
-        tokens = self.tokens[i+1:]
         tokenclasses = self.tokenclasses()[i+1:]
         try:
             i = tokenclasses.index(lp.AccidentalStyleSpecifier)
@@ -462,7 +461,6 @@ class Analyzer:
             return
         self.backuntil(lx.Space, lp.DotPath)
         i = max(indices)
-        tokens = self.tokens[i+1:]
         tokenclasses = self.tokenclasses()[i+1:]
         if lp.GrobName not in tokenclasses[:-1]:
             if lp.ContextName in tokenclasses:

--- a/frescobaldi/extensions/__init__.py
+++ b/frescobaldi/extensions/__init__.py
@@ -599,7 +599,6 @@ class Extensions(QObject):
         """
 
         inactive = self.inactive_extensions()
-        active = [key for key in self._infos.keys() if key not in inactive]
         inactive_dependencies = []
         missing_dependencies = []
         infos = self._infos
@@ -655,7 +654,6 @@ class Extensions(QObject):
 
         if missing_dependencies or inactive_dependencies or incoming:
             self._failed_dependencies = {}
-            message = []
             if missing_dependencies:
                 missing = self._failed_dependencies['missing'] = []
                 for dep in missing_dependencies:
@@ -707,7 +705,7 @@ class Extensions(QObject):
                 extension.set_load_time(
                     f"{(end - start) * 1000:.2f} ms")
                 self._extensions[ext] = extension
-            except Exception as e:
+            except Exception:
                 self._failed_extensions[ext] = sys.exc_info()
 
     def _load_icon(self, name):

--- a/frescobaldi/extensions/panel.py
+++ b/frescobaldi/extensions/panel.py
@@ -55,7 +55,7 @@ class ExtensionPanel(panel.Panel):
             if not hasattr(w, 'extension'):
                 w.extension = lambda: self.extension()
             return w
-        except Exception as e:
+        except Exception:
             # If the instantiation of the widget fails we create a nice
             # error message and return an "empty" FailedExtensionWidget instead.
             import sys

--- a/frescobaldi/job/lilypond.py
+++ b/frescobaldi/job/lilypond.py
@@ -215,19 +215,7 @@ class VolatileTextJob(PublishJob):
     base_dir can be used to add a 'virtual' document Directory
     in order to use relative includes.
     """
-    def __init__(
-        self, text, title=None, base_dir=None):
-        # TODO: ???
-        #       I have the impression this "info" stuff
-        #       is not used at all. And *if* it is used,
-        #       shouldn't it be implemented in LilyPondJob???
-        # Initialize default LilyPond version
-        info = lilypondinfo.preferred()
-        # Optionally infer a suitable LilyPond version from the content
-        if QSettings().value("lilypond_settings/autoversion", True, bool):
-            version = ly.docinfo.DocInfo(ly.document.Document(text, 'lilypond')).version()
-            if version:
-                info = lilypondinfo.suitable(version)
+    def __init__(self, text, title=None, base_dir=None):
         # Create temporary (document.Document object and file)
         self.directory = util.tempdir()
         filename = os.path.join(self.directory, 'document.ly')

--- a/frescobaldi/pitch/pitch.py
+++ b/frescobaldi/pitch/pitch.py
@@ -145,8 +145,9 @@ def getModalTransposer(document, mainwindow):
         if len(words) != 2:
             return False
         try:
-            steps = int(words[0])
-            keyIndex = ly.pitch.transpose.ModalTransposer.getKeyIndex(words[1])
+            # We're just interested in whether these raise an exception
+            int(words[0])   # steps
+            ly.pitch.transpose.ModalTransposer.getKeyIndex(words[1])
             return True
         except ValueError:
             return False

--- a/frescobaldi/preferences/general.py
+++ b/frescobaldi/preferences/general.py
@@ -219,7 +219,7 @@ class SessionsAndFiles(preferences.Group):
         basedir_layout = QHBoxLayout()
         save_layout.addLayout(basedir_layout)
 
-        self.basedirLabel = l = QLabel()
+        self.basedirLabel = QLabel()
         self.basedir = UrlRequester()
         basedir_layout.addWidget(self.basedirLabel)
         basedir_layout.addWidget(self.basedir)

--- a/frescobaldi/sessions/__init__.py
+++ b/frescobaldi/sessions/__init__.py
@@ -103,7 +103,6 @@ def loadSession(name):
     session = sessionGroup(name)
     urls = qsettings.get_url_list(session, "urls")
     active = session.value("active", -1, int)
-    result = None
     docs = []
     for url in urls:
         try:

--- a/frescobaldi/sessions/dialog.py
+++ b/frescobaldi/sessions/dialog.py
@@ -308,7 +308,7 @@ class SessionEditor(QDialog):
         """Add global paths (for edit)."""
         genPaths = self.fetchGenPaths()
         for p in genPaths:
-            i = QListWidgetItem(p, self.include.listBox)
+            QListWidgetItem(p, self.include.listBox)
 
     def clearPaths(self):
         """Remove all active paths."""

--- a/frescobaldi/viewers/contextmenu.py
+++ b/frescobaldi/viewers/contextmenu.py
@@ -91,7 +91,6 @@ class AbstractViewerContextMenu(QObject):
         opened viewer documents"""
         mds = self._actionCollection.viewer_document_select
         docs = mds.viewdocs()
-        document_actions = {}
         multi_docs = len(docs) > 1
         if self._panel.widget().currentViewdoc():
             current_doc_filename = self._panel.widget().currentViewdoc().filename()

--- a/frescobaldi/viewers/toolbar.py
+++ b/frescobaldi/viewers/toolbar.py
@@ -46,7 +46,7 @@ class AbstractViewerToolbar(QWidget):
 
     def __init__(self, parent, methods = None):
         super().__init__(parent)
-        self.actionCollection = ac = parent.actionCollection
+        self.actionCollection = parent.actionCollection
         self.createComponents()
         self.createLayout()
         self.populate(methods)

--- a/frescobaldi/vimode/__init__.py
+++ b/frescobaldi/vimode/__init__.py
@@ -156,6 +156,6 @@ here another line
 and here yet another
 """)
     e.show()
-    v = ViMode(e)
+    ViMode(e)
     a.exec()
 

--- a/frescobaldi/widgets/folding.py
+++ b/frescobaldi/widgets/folding.py
@@ -361,7 +361,6 @@ class Folder(QObject):
         if not r:
             return
         # if the last block starts a new region, don't hide it
-        count = 0
         end = r.end.previous() if self.fold_level(r.end).start else r.end
         # don't hide the first block of the region
         for block in cursortools.forwards(r.start.next(), end):


### PR DESCRIPTION
These are modifications to fix `ruff check --select F841`, unused variables.  There are still two outstanding warnings, but those are complex enough that I think they deserve their own PR.