### PR TITLE
Changes to the Score Wizard to remove unused variables.

### DIFF
--- a/frescobaldi/scorewiz/dialog.py
+++ b/frescobaldi/scorewiz/dialog.py
@@ -243,11 +243,9 @@ class Parts(Page):
                 parent = widget.scoreView
                 part = self._partTypes[name[:-4]]
                 box = QGroupBox(widget.partSettings)
-                item = score.PartItem(parent, part, box)
+                score.PartItem(parent, part, box)
             except KeyError:
-                # Unrecognized part type; fall back on a piano staff since
-                # they can hold almost anything.
-                partType = self._partTypes['piano']
+                pass
 
 
 class Settings(Page):

--- a/frescobaldi/scorewiz/score.py
+++ b/frescobaldi/scorewiz/score.py
@@ -125,7 +125,7 @@ class ScorePartsWidget(QSplitter):
                     parent.setExpanded(True)
                 else:
                     parent = self.scoreView
-                item = PartItem(parent, part, box)
+                PartItem(parent, part, box)
 
     def slotCurrentItemChanged(self, item):
         if isinstance(item, PartItem):


### PR DESCRIPTION
The last two instances of `ruff check --select F841` have been fixed.