### PR TITLE
Add installation instructions for non-technical Linux users

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,10 +15,13 @@ so, installing it is the easiest route, even though it might be out of date.
 Run `sudo apt install frescobaldi` on Debian/Ubuntu or `sudo dnf install
 frescobaldi` on Fedora.
 
-You can also install Frescobaldi from Flathub using Flatpak to get a more
-up-to-date application.
+You can also install [Frescobaldi from Flathub](https://flathub.org/apps/org.frescobaldi.Frescobaldi) using Flatpak to get a more up-to-date application:
 
-https://flathub.org/apps/org.frescobaldi.Frescobaldi
+```
+flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+flatpak install flathub org.frescobaldi.Frescobaldi
+flatpak run org.frescobaldi.Frescobaldi
+```
 
 If you previously installed Frescobaldi via your distribution, remember to
 remove it before installing it through Flatpak. Otherwise, they will coexist on

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,7 +25,64 @@ remove it before installing it through Flatpak. Otherwise, they will coexist on
 your computer; while this is not a problem per se, you could get the old
 Frescobaldi version when you launch Frescobaldi graphically.
 
+If you are *not* a developer and none of the options above are right for you, then install the compressed tar file (.tar.gz) using the instructions below.
 
+### Installing the compressed tar file
+
+It is a good idea to uninstall any previous versions before continuing.  See [Uninstalling other versions](#uninstalling-other-versions) for how to do this.
+
+#### Download, extract and move the Frescobaldi directory
+
+If you have not already done so, go to the [latest release page](https://github.com/frescobaldi/frescobaldi/releases/latest) and download the compressed tar file called `frescobaldi-x.y.z.tar.gz` (where `x`, `y`, and `z` are the version numbers), and extract the files from it.  You may be able to do this using GUI tools.  Your browser may extract the files when you click on the downloaded file, or using whatever File Manager you have, try double-clicking or right-clicking.  There are also third-party apps that will extract compressed files.
+
+Move the extracted directory to a permanent location, like your home directory.  (The rest of the instructions will assume that the extracted files are in the home directory.)
+
+If you can't extract the file using GUI tools, you can use the command line.  Get to a command prompt and `cd` to your Download directory.  This is often in your home directory, which you can get to by typing `cd` by itself.  Once in the download directory, use `ls` to make sure you have this file:
+
+    frescobaldi-x.y.z.tar.gz
+
+To extract the file, type
+
+    tar xvf frescobaldi-x.y.z.tar.gz
+
+You should now have the directory `frescobaldi-x.y.z` in your download directory.  Move it to your home directory by typing
+
+    mv frescobaldi-x.y.z ~
+
+#### Install the necessary tools
+
+At this point, if you have been using GUI tools, you will need to get to the command line.  We will now install some tools needed to install Frescobaldi.  You only have to do this once.  The next release you install, you can skip this.  If you are on a Debian/Ubuntu-like distribution, type:
+
+    sudo apt install pipx gettext libportmidi0 libxcb-cursor0
+
+If you are on Fedora, type:
+
+    sudo dnf install pipx gettext portmidi
+
+#### Install using `pipx`
+
+At the command line, type:
+
+    cd ~/frescobaldi-x.y.z
+    pipx install .
+
+After a few moments, `pipx` will say Frescobaldi is installed.  Next, install the desktop shortcut (this is all one command):
+
+    desktop-file-install --dir ~/.local/share/applications/ --set-icon $PWD/frescobaldi/icons/org.frescobaldi.Frescobaldi.svg  linux/org.frescobaldi.Frescobaldi.desktop
+
+Now update the desktop database:
+
+    update-desktop-database ~/.local/share/
+
+ If this is your first time installing using `pipx`, type the following:
+
+    pipx ensurepath
+
+Then type `exit` and restart your command line shell.  Now you can to type:
+
+    frescobaldi
+
+...and Frescobaldi will start up.
 
 ## Developing Frescobaldi
 


### PR DESCRIPTION
I added a section in INSTALL.md for non-technical Linux users who are downloading the compressed tar file in the release website.  Fixes #2026 