### PR TITLE
4.0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ Click on the version to see the complete list of commits in a release.
 
 ## [unreleased]
 
+## [4.0.4] - 2025-08-08
+
+### Fixed
+
+- MIDI input now works reliably on all operating systems and macOS in particular (#2060).
+- Avoid MIDI playback issues while using multiple windows (#2053).
+- Set the maximum zoom for the PDF viewer to 800%. This is to prevent qpageview performance issues, but it's also a reasonable max value (#2056).
+- Fix snippet shortcuts breaking when a main window is closed (#2048).
+- Prevent crashes on Windows when opening the Documentation Browser (#2016).
+- Fix open .ly file from Finder (macOS) (#2051).
+- The Raster page layout option has been renamed Grid layout and a tooltip now explains how it works (#2027). This requires qpageview 1.0.1.
+- Some small bugfixes.
+
+### Changed
+
+- Remove pygame from project dependencies and let Linux packagers use PortMidi instead (#2007).
+- Since the release of Briefcase version 0.3.24, file associations are now supported also on macOS (#2057).
+- The tarball used by packagers is now built automatically by a GitHub Action workflow (#2000).
+- Improve the installation instructions (#2028).
+- Updated translations: Japanese, Korean.
+
+### Added
+
+- Doc: explain how to backup the settings (#2043).
+
+
 ## [4.0.3] - 2025-06-09
 
 ### Fixed
@@ -1670,7 +1696,8 @@ Frescobaldi application itself has the PO files in i18n/frescobaldi, see
 
 * Initial release.
 
-[unreleased]: https://github.com/frescobaldi/frescobaldi/compare/v4.0.3...master
+[unreleased]: https://github.com/frescobaldi/frescobaldi/compare/v4.0.4...master
+[4.0.4]: https://github.com/frescobaldi/frescobaldi/compare/v4.0.3...v4.0.4
 [4.0.3]: https://github.com/frescobaldi/frescobaldi/compare/v4.0.2...v4.0.3
 [4.0.2]: https://github.com/frescobaldi/frescobaldi/compare/v4.0.1...v4.0.2
 [4.0.1]: https://github.com/frescobaldi/frescobaldi/compare/v4.0.0...v4.0.1

--- a/frescobaldi/appinfo.py
+++ b/frescobaldi/appinfo.py
@@ -25,7 +25,7 @@ Information about the Frescobaldi application.
 # these variables are also used by the distutils setup
 name = "frescobaldi"
 # https://packaging.python.org/en/latest/discussions/versioning/
-version = "4.0.4.dev1"
+version = "4.0.4"
 extension_api = "0.9.0"
 description = "LilyPond Music Editor"
 long_description = \

--- a/linux/org.frescobaldi.Frescobaldi.metainfo.xml.in
+++ b/linux/org.frescobaldi.Frescobaldi.metainfo.xml.in
@@ -78,6 +78,7 @@
   <translation type="gettext">userguide</translation>
 
   <releases>
+    <release version="4.0.4" date="2025-08-08" />
     <release version="4.0.3" date="2025-06-09" />
     <release version="4.0.2" date="2025-05-06" />
     <release version="4.0.1" date="2025-04-03" />

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,13 +87,13 @@ project_name = "frescobaldi"
 bundle = "org.frescobaldi"
 # Briefcase does not support dynamic version yet.
 # https://github.com/beeware/briefcase/issues/474
-version = "4.0.4.dev1"
+version = "4.0.4"
 requires = [
-    "PyQt6==6.9.0",
-    "PyQt6-Qt6==6.9.0",
-    "PyQt6-sip==13.10.0",
+    "PyQt6==6.9.1",
+    "PyQt6-Qt6==6.9.1",
+    "PyQt6-sip==13.10.2",
     "PyQt6-WebEngine==6.9.0",
-    "PyQt6-WebEngine-Qt6==6.9.0",
+    "PyQt6-WebEngine-Qt6==6.9.1",
     "python-ly==0.9.9",
     "qpageview==1.0.1",
     "pygame-ce==2.5.5"


### PR DESCRIPTION
File associations should now work fine on Windows
and macOS since briefcase version 0.3.24.

This is currently a draft. I want other open PRs to be merged before making the release. The target date is Tuesday 29th of July.

