### PR TITLE
Always use the current shorthand for staccatissimo

### DIFF
--- a/frescobaldi/quickinsert/articulations.py
+++ b/frescobaldi/quickinsert/articulations.py
@@ -47,7 +47,7 @@ shorthands = {
     'marcato': '^',
     'stopped': '+',
     'tenuto': '-',
-    'staccatissimo': '|', # in Lily >= 2.17.25 this changed to '!', handled below
+    'staccatissimo': '!',
     'accent': '>',
     'staccato': '.',
     'portato': '_',
@@ -120,11 +120,6 @@ class Group(buttongroup.ButtonGroup):
     def actionTriggered(self, name):
         if self.tool().shorthands.isChecked() and name in shorthands:
             short = shorthands[name]
-            # LilyPond >= 2.17.25 changed -| to -!
-            if name == 'staccatissimo':
-                version = documentinfo.docinfo(self.mainwindow().currentDocument()).version()
-                if version >= (2, 17, 25):
-                    short = '!'
             text = '_-^'[self.direction()+1] + short
         else:
             text = ('_', '', '^')[self.direction()+1] + '\\' + name


### PR DESCRIPTION
-! is the shorthand for staccatissimo since lilypond 2.18. No need to deal with older syntax.

Fix #2042