### PR TITLE
Modifications to fix ruff warnings, redefined while unused (F811)

### DIFF
--- a/frescobaldi/debug.py
+++ b/frescobaldi/debug.py
@@ -25,24 +25,24 @@ def doc_repr(self):
 document.Document.__repr__ = doc_repr
 
 @app.documentCreated.connect
-def f_doc_created(doc):
+def doc_created(doc):
     print("created:", doc)
 
 @app.documentLoaded.connect
-def f_doc_loaded(doc):
+def doc_loaded(doc):
     print("loaded:", doc)
 
 @app.documentClosed.connect
-def f_doc_closed(doc):
+def doc_closed(doc):
     print("closed:", doc)
 
 @app.jobStarted.connect
-def f_job_started(doc, job):
+def job_started(doc, job):
     print('job started:', doc)
     print(job.command)
 
 @app.jobFinished.connect
-def f_job_finished(doc, job, success):
+def job_finished(doc, job, success):
     print('job finished', doc)
     print('success:', success)
 
@@ -51,7 +51,7 @@ def f_job_finished(doc, job, success):
 
 
 # delete unneeded stuff
-del doc_repr, f_doc_created, f_doc_loaded, f_doc_closed, f_job_started, f_job_finished
+del doc_repr, doc_created, doc_loaded, doc_closed, job_started, job_finished
 
 def modules():
     """Print the list of loaded modules."""

--- a/frescobaldi/debug.py
+++ b/frescobaldi/debug.py
@@ -25,24 +25,24 @@ def doc_repr(self):
 document.Document.__repr__ = doc_repr
 
 @app.documentCreated.connect
-def f(doc):
+def f_doc_created(doc):
     print("created:", doc)
 
 @app.documentLoaded.connect
-def f(doc):
+def f_doc_loaded(doc):
     print("loaded:", doc)
 
 @app.documentClosed.connect
-def f(doc):
+def f_doc_closed(doc):
     print("closed:", doc)
 
 @app.jobStarted.connect
-def f(doc, job):
+def f_job_started(doc, job):
     print('job started:', doc)
     print(job.command)
 
 @app.jobFinished.connect
-def f(doc, job, success):
+def f_job_finished(doc, job, success):
     print('job finished', doc)
     print('success:', success)
 
@@ -51,7 +51,7 @@ def f(doc, job, success):
 
 
 # delete unneeded stuff
-del f, doc_repr
+del doc_repr, f_doc_created, f_doc_loaded, f_doc_closed, f_job_started, f_job_finished
 
 def modules():
     """Print the list of loaded modules."""

--- a/frescobaldi/documenttooltip.py
+++ b/frescobaldi/documenttooltip.py
@@ -35,7 +35,6 @@ import tokeniter
 import highlighter
 import textformats
 import gadgets.customtooltip
-import tokeniter
 import ly.lex.lilypond
 
 

--- a/frescobaldi/externalchanges/widget.py
+++ b/frescobaldi/externalchanges/widget.py
@@ -33,7 +33,6 @@ import qutil
 import util
 import icons
 import htmldiff
-import document
 import widgets.dialog
 import documentwatcher
 import userguide

--- a/frescobaldi/scorewiz/parts/__init__.py
+++ b/frescobaldi/scorewiz/parts/__init__.py
@@ -60,7 +60,7 @@ from . import (
 
 
 
-def model():
+def model(): # noqa: F811 Creating a singleton
     """Returns all available part types as a hierarchical model."""
     m = Model(QApplication.instance())
     global model

--- a/frescobaldi/scorewiz/parts/__init__.py
+++ b/frescobaldi/scorewiz/parts/__init__.py
@@ -60,6 +60,7 @@ from . import (
 
 
 _model = None
+
 def model():
     """Returns all available part types as a hierarchical model."""
     global _model

--- a/frescobaldi/scorewiz/parts/__init__.py
+++ b/frescobaldi/scorewiz/parts/__init__.py
@@ -59,13 +59,13 @@ from . import (
 
 
 
-
-def model(): # noqa: F811 Creating a singleton
+_model = None
+def model():
     """Returns all available part types as a hierarchical model."""
-    m = Model(QApplication.instance())
-    global model
-    model = lambda: m
-    return m
+    global _model
+    if _model is None:
+        _model = Model(QApplication.instance())
+    return _model
 
 
 class Model(QAbstractItemModel):

--- a/frescobaldi/snippet/insert.py
+++ b/frescobaldi/snippet/insert.py
@@ -22,8 +22,6 @@ Insert snippets into a Document.
 """
 
 
-import sys
-
 from PyQt6.QtCore import QSettings
 from PyQt6.QtGui import QTextCursor
 from PyQt6.QtWidgets import QMessageBox

--- a/frescobaldi/snippet/model.py
+++ b/frescobaldi/snippet/model.py
@@ -34,6 +34,7 @@ import actioncollection
 from . import snippets, tool
 
 _model = None
+
 def model():
     """Returns the global model containing snippets."""
     global _model

--- a/frescobaldi/snippet/model.py
+++ b/frescobaldi/snippet/model.py
@@ -33,13 +33,13 @@ import actioncollection
 
 from . import snippets, tool
 
-
-def model(): # noqa: F811 Creating a singleton
+_model = None
+def model():
     """Returns the global model containing snippets."""
-    m = SnippetModel(app.qApp)
-    global model
-    model = lambda: m
-    return m
+    global _model
+    if _model is None:
+        _model = SnippetModel(app.qApp)
+    return _model
 
 
 class SnippetModel(QAbstractItemModel):

--- a/frescobaldi/snippet/model.py
+++ b/frescobaldi/snippet/model.py
@@ -34,7 +34,7 @@ import actioncollection
 from . import snippets, tool
 
 
-def model():
+def model(): # noqa: F811 Creating a singleton
     """Returns the global model containing snippets."""
     m = SnippetModel(app.qApp)
     global model

--- a/frescobaldi/vcs/menu.py
+++ b/frescobaldi/vcs/menu.py
@@ -28,7 +28,6 @@ from PyQt6.QtGui import QAction, QActionGroup
 from PyQt6.QtWidgets import QMenu, QMessageBox
 
 import app
-import mainwindow
 import plugin
 import vcs
 from .gitrepo import GitError


### PR DESCRIPTION
Modifications have been made so that the ruff linter warnings for "redefined while used" (F811) are gone.

	$ ruff check --select F811
	All checks passed!

There were two instances where the code took this form:

	def foo():
		f = Bar()
		global foo
		foo = lambda: f
		return f

I'm assuming this is a Pythonic way to create a singleton and I marked the code so that ruff would skip the checks on those.  I don't know of a way to create a singleton in Python that ruff will pass.