### PR TITLE
Better regex for finding pitch names in MIDI input

### DIFF
--- a/frescobaldi/midiinput/__init__.py
+++ b/frescobaldi/midiinput/__init__.py
@@ -29,12 +29,16 @@ import documentinfo
 
 from . import elements
 
-# What this does was originally undocumented. It appears intended to match
-# chord and pitch names, but not commands or variables (thanks @ksnortum)
+# Match LilyPond pitch names and chords, but not variables or commands
 LY_REG_EXPR = re.compile(
-    r'(?<![a-zA-Z#_^\-\\])[a-ps-zA-PS-Z]{1,3}(?![a-zA-Z])[\'\,]*'
-    '|'
-    r'(?<![<\\])<[^<>]*>(?!>)'
+    r"(?<![a-zA-Z_\\:#\"-])" # Ensure no letters, underscores, or special characters precede
+        r"(?:(?:(?:do|re|ré|mi|fa|sol|la|si)[db]{0,2})" # do re mi pitch names and modifiers
+        r"|" # or ...
+        r"(?:(?:[a-h](?:s|is|x|f|es|as){0,2})))" # a b c pitch names and modifiers
+        r"[',]*" # optional octave indicators
+        r"(?![a-zA-Z_\"-])" # Ensure no letters, or special characters follow
+    r"|" # or ...
+    r"(?<![<\\])<[^<>]*>(?!>)" # Match angle brackets with content inside
 )
 
 # Event codes from the MIDI specification


### PR DESCRIPTION
I am very nervous about this PR!  I don't have a way to test it in Frescobaldi because I can't get MIDI input to work for me. (I *have* tested it in a Python program I wrote and at Regex101.com.)

 I would love volunteers to test MIDI input with the "re-pitch" checkbox checked.  I believe this will take an existing piece, find the next pitch name, and replace it with the MIDI input.  It would be great to test it before and after the PR is applied so that we can tell if re-pitch is actual working.  My hunch is that it won't work well in some languages.

Ideally, this PR would be testing with "a b c" pitch name languages (like English or Netherlands) and "do re mi" pitch name languages (like Italian or French).  @kledeen, would you be willing to test this?