### PR TITLE
Avoid doubling starting and ending braces with Cut and Assign

### DIFF
--- a/frescobaldi/cut_assign.py
+++ b/frescobaldi/cut_assign.py
@@ -88,6 +88,8 @@ def cut_assign(cursor):
             break
     insert = QTextCursor(block)
     text = cursor.selection().toPlainText()
+    if text.startswith("{") and text.endswith("}"):
+        text = text.removeprefix("{").removesuffix("}").strip()
     space = '\n' if '\n' in text else ' '
     text = ''.join((name, ' =', mode, ' {', space, text, space, '}\n\n'))
     with cursortools.compress_undo(cursor):


### PR DESCRIPTION
Sometimes when you used Advanced Cut and Assign (`Ctrl-Shift-X`) the copied text would have two starting and two ending braces.  Although this wasn't a syntax error in LilyPond, it was an annoyance.

Below is a LilyPond input file that I used to test the PR.  Note that cutting and assigning the text after `\chordmode` and `\lyricmode` produce an error, but this was true even before the PR.

``` lilypond
\version "2.26.0"

instA = { c'4 f g a }

\score {
  <<
    \new Staff \instA
    \new Staff { a4 c' d' f' }
    \new Staff \relative { c'4 d f g }
    \new Staff \fixed c' { c4 d e f }
    \new ChordNames \chordmode { c4 d:m f g }
    \new Lyrics \lyricmode { I am hap -- py }
  >>
}
```