### PR TITLE
Apply spaces with in-line comments consistently

### DIFF
--- a/frescobaldi/snippet/builtin.py
+++ b/frescobaldi/snippet/builtin.py
@@ -443,12 +443,12 @@ def lilypond():
         if text.endswith('\n'):
             return '% ' + text[:-1].replace('\n', '\n% ') + '\n'
         elif after and not after.isspace():
-            return '%{ ' + text + '%} '
+            return '%{ ' + text + ' %}'
         else:
             return '% ' + text.replace('\n', '\n% ')
     elif text:
         if after and not after.isspace():
-            return '%{ ' + text + '%} '
+            return '%{ ' + text + ' %}'
         else:
             return '% ' + text + after
     else:
@@ -497,7 +497,9 @@ def main():
                 text = text.lstrip()[3:]
             else:
                 text = text.lstrip()[2:]
-            if text.rstrip().endswith('%}'):
+            if text.rstrip().endswith(' %}'):
+                text = text.rstrip()[:-3]
+            elif text.rstrip().endswith('%}'):
                 text = text.rstrip()[:-2]
         else:
             if not text:


### PR DESCRIPTION
Before this change, creating an in-line comment placed a space after the `%}` characters, not before.  This created a lop-sided comment.  Changes to the uncomment logic make sure the space before the `%}` is removed.

To illustrate, say we have this input file fragment:

```lilypond
\relative {
  c'1 d1 c1
}
```

Highlight the `d1` and press Ctrl-Alt-C twice to comment it.  Before the change you would get:

```lilypond
\relative {
  c'1 %{ d1%}  c1
}
```

After the change, you get:

```lilypond
\relative {
  c'1 %{ d1 %} c1
}
```

Highlighting the in-line comment and pressing Ctrl-Alt-C, Ctrl-Alt-U to uncomment now returns the code to its original state without extra spaces.