### PR TITLE
Catch AttributeError in BookmarkManager.updateMarkStatus()

### DIFF
--- a/frescobaldi/bookmarkmanager.py
+++ b/frescobaldi/bookmarkmanager.py
@@ -58,9 +58,13 @@ class BookmarkManager(plugin.MainWindowPlugin):
         bookmarks.bookmarks(doc).marksChanged.connect(self.updateMarkStatus)
 
     def updateMarkStatus(self):
-        view = self.mainwindow().currentView()
-        self.actionCollection.view_bookmark.setChecked(
-            bookmarks.bookmarks(view.document()).hasMark(view.textCursor().blockNumber(), 'mark'))
+        try:
+            view = self.mainwindow().currentView()
+            self.actionCollection.view_bookmark.setChecked(
+                bookmarks.bookmarks(view.document()).hasMark(view.textCursor().blockNumber(), 'mark'))
+        except AttributeError:
+            pass    # on macOS there is no view if the last window is closed
+                    # but the application is still running (issue #2230)
 
     def markCurrentLine(self):
         view = self.mainwindow().currentView()


### PR DESCRIPTION
Fixes #2230. To me this feels more like a surface patch than one that addresses the root cause, but the bug appears to be macOS-specific, which is difficult to troubleshoot without a Mac of my own to test on.