### PR TITLE
Catch RuntimeError in ActionCollection.reloadOthers()

### DIFF
--- a/frescobaldi/actioncollection.py
+++ b/frescobaldi/actioncollection.py
@@ -362,4 +362,7 @@ class ShortcutCollection(ActionCollectionBase):
             if not other:
                 self.others[self.name].remove(ref)
             elif other is not self:
-                other.load()
+                try:
+                    other.load()
+                except RuntimeError:
+                    pass    # fix another Weird Mac Thing (issue #2223)


### PR DESCRIPTION
Fixes #2223. As with many of these macOS-specific bugs, I'm not sure exactly what triggers it, but I'm guessing it's something like a closed window whose objects Qt has already cleaned up but Python hasn't yet. This would therefore seem the correct place to catch the exception.